### PR TITLE
Prefer to use std::shared_ptr instead of std::tr1::shared_ptr etc

### DIFF
--- a/cache.h
+++ b/cache.h
@@ -22,7 +22,7 @@ class cache
 public:
 	typedef TKey key_type;
 	typedef TValue mapped_type;
-	typedef std::tr1::shared_ptr< mapped_type > ptr_type;
+	typedef stdext::shared_ptr< mapped_type > ptr_type;
 
 private:
 	typedef std::pair< key_type, ptr_type > value_type;

--- a/epg_events.h
+++ b/epg_events.h
@@ -16,7 +16,7 @@ namespace vdrlive
 
 	class EpgInfo;
 
-	typedef std::tr1::shared_ptr<EpgInfo> EpgInfoPtr;
+	typedef stdext::shared_ptr<EpgInfo> EpgInfoPtr;
 
 	// -------------------------------------------------------------------------
 

--- a/grab.h
+++ b/grab.h
@@ -7,7 +7,7 @@
 
 namespace vdrlive {
 
-typedef std::tr1::shared_ptr< char > GrabImagePtr;
+typedef stdext::shared_ptr< char > GrabImagePtr;
 typedef std::pair< GrabImagePtr, int > GrabImageInfo;
 
 class GrabImageTask;

--- a/pages/epginfo.ecpp
+++ b/pages/epginfo.ecpp
@@ -22,7 +22,7 @@ namespace vdrlive {
 			cSchedulesLock m_schedulesLock;
 	};
 
-	typedef std::tr1::shared_ptr<SchedulesLock> SchedulesLockPtr;
+	typedef stdext::shared_ptr<SchedulesLock> SchedulesLockPtr;
 }
 #endif
 

--- a/recman.cpp
+++ b/recman.cpp
@@ -22,10 +22,10 @@ namespace vdrlive {
 	/**
 	 *  Implementation of class RecordingsManager:
 	 */
-	std::tr1::weak_ptr< RecordingsManager > RecordingsManager::m_recMan;
-	std::tr1::shared_ptr< RecordingsTree > RecordingsManager::m_recTree;
-	std::tr1::shared_ptr< RecordingsList > RecordingsManager::m_recList;
-	std::tr1::shared_ptr< DirectoryList > RecordingsManager::m_recDirs;
+	stdext::weak_ptr< RecordingsManager > RecordingsManager::m_recMan;
+	stdext::shared_ptr< RecordingsTree > RecordingsManager::m_recTree;
+	stdext::shared_ptr< RecordingsList > RecordingsManager::m_recList;
+	stdext::shared_ptr< DirectoryList > RecordingsManager::m_recDirs;
 #if VDRVERSNUM >= 20301
 	cStateKey RecordingsManager::m_recordingsStateKey;
 #else
@@ -38,7 +38,7 @@ namespace vdrlive {
 	// use any longer, it will be freed automaticaly, which leads to a
 	// release of the VDR recordings lock. Upon requesting access to
 	// the RecordingsManager via LiveRecordingsManger function, first
-	// the weak ptr is locked (obtaining a std::tr1::shared_ptr from an possible
+	// the weak ptr is locked (obtaining a stdext::shared_ptr from an possible
 	// existing instance) and if not successfull a new instance is
 	// created, which again locks the VDR Recordings.
 	//
@@ -61,7 +61,7 @@ namespace vdrlive {
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (! recMan) {
-			return RecordingsTreePtr(recMan, std::tr1::shared_ptr< RecordingsTree >());
+			return RecordingsTreePtr(recMan, stdext::shared_ptr< RecordingsTree >());
 		}
 		return RecordingsTreePtr(recMan, m_recTree);
 	}
@@ -70,25 +70,25 @@ namespace vdrlive {
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (! recMan) {
-			return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >());
+			return RecordingsListPtr(recMan, stdext::shared_ptr< RecordingsList >());
 		}
-		return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
+		return RecordingsListPtr(recMan, stdext::shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
 	}
 
 	RecordingsListPtr RecordingsManager::GetRecordingsList(time_t begin, time_t end, bool ascending) const
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (! recMan) {
-			return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >());
+			return RecordingsListPtr(recMan, stdext::shared_ptr< RecordingsList >());
 		}
-		return RecordingsListPtr(recMan, std::tr1::shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
+		return RecordingsListPtr(recMan, stdext::shared_ptr< RecordingsList >(new RecordingsList(m_recList, ascending)));
 	}
 
 	DirectoryListPtr RecordingsManager::GetDirectoryList() const
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (!recMan) {
-			return DirectoryListPtr(recMan, std::tr1::shared_ptr< DirectoryList >());
+			return DirectoryListPtr(recMan, stdext::shared_ptr< DirectoryList >());
 		}
 		return DirectoryListPtr(recMan, m_recDirs);
 	}
@@ -278,7 +278,7 @@ namespace vdrlive {
 	RecordingsManagerPtr RecordingsManager::EnsureValidData()
 	{
 		// Get singleton instance of RecordingsManager.  'this' is not
-		// an instance of std::tr1::shared_ptr of the singleton
+		// an instance of stdext::shared_ptr of the singleton
 		// RecordingsManager, so we obtain it in the overall
 		// recommended way.
 		RecordingsManagerPtr recMan = LiveRecordingsManager();
@@ -302,21 +302,21 @@ namespace vdrlive {
 				m_recDirs.reset();
 			}
 			if (stateChanged || !m_recTree) {
-				m_recTree = std::tr1::shared_ptr< RecordingsTree >(new RecordingsTree(recMan));
+				m_recTree = stdext::shared_ptr< RecordingsTree >(new RecordingsTree(recMan));
 			}
 			if (!m_recTree) {
 				esyslog("live: creation of recordings tree failed!");
 				return RecordingsManagerPtr();
 			}
 			if (stateChanged || !m_recList) {
-				m_recList = std::tr1::shared_ptr< RecordingsList >(new RecordingsList(RecordingsTreePtr(recMan, m_recTree)));
+				m_recList = stdext::shared_ptr< RecordingsList >(new RecordingsList(RecordingsTreePtr(recMan, m_recTree)));
 			}
 			if (!m_recList) {
 				esyslog("live: creation of recordings list failed!");
 				return RecordingsManagerPtr();
 			}
 			if (stateChanged || !m_recDirs) {
-				m_recDirs = std::tr1::shared_ptr< DirectoryList >(new DirectoryList(recMan));
+				m_recDirs = stdext::shared_ptr< DirectoryList >(new DirectoryList(recMan));
 			}
 			if (!m_recDirs) {
 				esyslog("live: creation of directory list failed!");
@@ -585,13 +585,13 @@ namespace vdrlive {
 	 *  Implementation of class RecordingsTreePtr:
 	 */
 	RecordingsTreePtr::RecordingsTreePtr() :
-		std::tr1::shared_ptr<RecordingsTree>(),
+		stdext::shared_ptr<RecordingsTree>(),
 		m_recManPtr()
 	{
 	}
 
-	RecordingsTreePtr::RecordingsTreePtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< RecordingsTree > recTree) :
-		std::tr1::shared_ptr<RecordingsTree>(recTree),
+	RecordingsTreePtr::RecordingsTreePtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr< RecordingsTree > recTree) :
+		stdext::shared_ptr<RecordingsTree>(recTree),
 		m_recManPtr(recManPtr)
 	{
 	}
@@ -629,7 +629,7 @@ namespace vdrlive {
 		}
 	}
 
-	RecordingsList::RecordingsList(std::tr1::shared_ptr< RecordingsList > recList, bool ascending) :
+	RecordingsList::RecordingsList(stdext::shared_ptr< RecordingsList > recList, bool ascending) :
 		m_pRecVec(new RecVecType(recList->size()))
 	{
 		if (!m_pRecVec) {
@@ -643,7 +643,7 @@ namespace vdrlive {
 		}
 	}
 
-	RecordingsList::RecordingsList(std::tr1::shared_ptr< RecordingsList > recList, time_t begin, time_t end, bool ascending) :
+	RecordingsList::RecordingsList(stdext::shared_ptr< RecordingsList > recList, time_t begin, time_t end, bool ascending) :
 		m_pRecVec(new RecVecType())
 	{
 		if (end > begin) {
@@ -685,8 +685,8 @@ namespace vdrlive {
 	/**
 	 *  Implementation of class RecordingsList:
 	 */
-	RecordingsListPtr::RecordingsListPtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< RecordingsList > recList) :
-		std::tr1::shared_ptr< RecordingsList >(recList),
+	RecordingsListPtr::RecordingsListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr< RecordingsList > recList) :
+		stdext::shared_ptr< RecordingsList >(recList),
 		m_recManPtr(recManPtr)
 	{
 	}
@@ -755,8 +755,8 @@ namespace vdrlive {
 	/**
 	 *  Implementation of class DirectoryListPtr:
 	 */
-	DirectoryListPtr::DirectoryListPtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< DirectoryList > recDirs) :
-		std::tr1::shared_ptr< DirectoryList >(recDirs),
+	DirectoryListPtr::DirectoryListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr< DirectoryList > recDirs) :
+		stdext::shared_ptr< DirectoryList >(recDirs),
 		m_recManPtr(recManPtr)
 	{
 	}

--- a/recman.h
+++ b/recman.h
@@ -15,7 +15,7 @@ namespace vdrlive {
 
 	// Forward declations from epg_events.h
 	class EpgInfo;
-	typedef std::tr1::shared_ptr<EpgInfo> EpgInfoPtr;
+	typedef stdext::shared_ptr<EpgInfo> EpgInfoPtr;
 
 	/**
 	 *  Some forward declarations
@@ -29,9 +29,9 @@ namespace vdrlive {
 	class DirectoryListPtr;
 	class RecordingsItem;
 
-	typedef std::tr1::shared_ptr< RecordingsManager > RecordingsManagerPtr;
-	typedef std::tr1::shared_ptr< RecordingsItem > RecordingsItemPtr;
-	typedef std::tr1::weak_ptr< RecordingsItem > RecordingsItemWeakPtr;
+	typedef stdext::shared_ptr< RecordingsManager > RecordingsManagerPtr;
+	typedef stdext::shared_ptr< RecordingsItem > RecordingsItemPtr;
+	typedef stdext::weak_ptr< RecordingsItem > RecordingsItemWeakPtr;
 	typedef std::multimap< std::string, RecordingsItemPtr > RecordingsMap;
 
 
@@ -127,10 +127,10 @@ namespace vdrlive {
 #endif
 			static RecordingsManagerPtr EnsureValidData();
 
-			static std::tr1::weak_ptr< RecordingsManager > m_recMan;
-			static std::tr1::shared_ptr< RecordingsTree > m_recTree;
-			static std::tr1::shared_ptr< RecordingsList > m_recList;
-			static std::tr1::shared_ptr< DirectoryList > m_recDirs;
+			static stdext::weak_ptr< RecordingsManager > m_recMan;
+			static stdext::shared_ptr< RecordingsTree > m_recTree;
+			static stdext::shared_ptr< RecordingsList > m_recList;
+			static stdext::shared_ptr< DirectoryList > m_recDirs;
 #if VDRVERSNUM >= 20301
 			static cStateKey m_recordingsStateKey;
 #else
@@ -299,12 +299,12 @@ namespace vdrlive {
 	 *  A smart pointer to a recordings tree. As long as an instance of this
 	 *  exists the recordings are locked in the vdr.
 	 */
-	class RecordingsTreePtr : public std::tr1::shared_ptr< RecordingsTree >
+	class RecordingsTreePtr : public stdext::shared_ptr< RecordingsTree >
 	{
 		friend class RecordingsManager;
 
 		private:
-			RecordingsTreePtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< RecordingsTree > recTree);
+			RecordingsTreePtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr< RecordingsTree > recTree);
 
 		public:
 			RecordingsTreePtr();
@@ -328,8 +328,8 @@ namespace vdrlive {
 
 		private:
 			RecordingsList(RecordingsTreePtr recTree);
-			RecordingsList(std::tr1::shared_ptr< RecordingsList > recList, bool ascending);
-			RecordingsList(std::tr1::shared_ptr< RecordingsList > recList, time_t begin, time_t end, bool ascending);
+			RecordingsList(stdext::shared_ptr< RecordingsList > recList, bool ascending);
+			RecordingsList(stdext::shared_ptr< RecordingsList > recList, time_t begin, time_t end, bool ascending);
 
 		public:
 			typedef std::vector< RecordingsItemPtr > RecVecType;
@@ -375,12 +375,12 @@ namespace vdrlive {
 	 *  A smart pointer to a recordings list. As long as an instance of this
 	 *  exists the recordings are locked in the vdr.
 	 */
-	class RecordingsListPtr : public std::tr1::shared_ptr< RecordingsList >
+	class RecordingsListPtr : public stdext::shared_ptr< RecordingsList >
 	{
 		friend class RecordingsManager;
 
 		private:
-			RecordingsListPtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< RecordingsList > recList);
+			RecordingsListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr< RecordingsList > recList);
 
 		public:
 			virtual ~RecordingsListPtr();
@@ -419,12 +419,12 @@ namespace vdrlive {
 	 *  A smart pointer to a directory list. As long as an instance of this
 	 *  exists the recordings are locked in the vdr.
 	 */
-	class DirectoryListPtr : public std::tr1::shared_ptr< DirectoryList >
+	class DirectoryListPtr : public stdext::shared_ptr< DirectoryList >
 	{
 		friend class RecordingsManager;
 
 		private:
-			DirectoryListPtr(RecordingsManagerPtr recManPtr, std::tr1::shared_ptr< DirectoryList > recDirs);
+			DirectoryListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr< DirectoryList > recDirs);
 
 		public:
 			virtual ~DirectoryListPtr();

--- a/stdext.h
+++ b/stdext.h
@@ -1,10 +1,19 @@
 #ifndef VDR_LIVE_STDEXT_H
 #define VDR_LIVE_STDEXT_H
 
-#if __GNUC__ >= 4
+#if __cplusplus >= 201103L
+
+#	include <functional>
+#	include <memory>
+
+namespace stdext = std;
+
+#elif __GNUC__ >= 4
 
 #	include <tr1/functional>
 #	include <tr1/memory>
+
+namespace stdext = std::tr1;
 
 #else
 
@@ -24,8 +33,7 @@
 #		include <boost/shared_ptr.hpp>
 #		include <boost/weak_ptr.hpp>
 
-namespace std {
-namespace tr1 {
+namespace stdext {
 
 	using boost::bind;
 	using boost::shared_ptr;
@@ -43,8 +51,7 @@ namespace tr1 {
 		using ::_9;
 	}
 
-} // namespace std
-} // namespace tr1
+} // namespace stdext
 
 #	else
 

--- a/tasks.cpp
+++ b/tasks.cpp
@@ -17,13 +17,8 @@
 namespace vdrlive {
 
 using std::for_each;
-#if __cplusplus >= 201103L
-using std::bind;
-using namespace std::placeholders;
-#else
-using std::tr1::bind;
-using namespace std::tr1::placeholders;
-#endif
+using stdext::bind;
+using namespace stdext::placeholders;
 
 const char* NowReplaying()
 {

--- a/timerconflict.h
+++ b/timerconflict.h
@@ -69,7 +69,7 @@ namespace vdrlive {
 	class TimerConflictNotifier
 	{
 		public:
-			typedef std::tr1::shared_ptr<TimerConflicts> TimerConflictsPtr;
+			typedef stdext::shared_ptr<TimerConflicts> TimerConflictsPtr;
 
 			TimerConflictNotifier();
 			virtual ~TimerConflictNotifier();


### PR DESCRIPTION
This patch replaces uses of TR1 utilities such as std::tr1::shared_ptr
and std::tr1::bind with the C++11 equivalents (when available).

The solution used is to define a new namespace alias, stdext, and then
refer to stdext::shared_ptr instead of std::tr1::shared_ptr, and
similarly for weak_ptr and bind. When neither C++11 or TR1 is
available, Boost is used as before, and the Boost versions of those
utilities are added to namespace stdext.

A similar change was already made to prefer std::bind to std::tr1::bind,
in commit 79b7394db7623f6d588b048fca1ab6f2266731f8. That change to
tasks.cpp can be simplified by reusing the stdext alias introduced by
this patch.

Fixes:
https://projects.vdr-developer.org/issues/2611
https://projects.vdr-developer.org/issues/2612