### PR TITLE
remove any 'using namespace std;'

### DIFF
--- a/epg_events.cpp
+++ b/epg_events.cpp
@@ -15,7 +15,6 @@
 #define TVM2VDR_PL_WORKAROUND  0
 #endif
 
-using namespace std;
 
 namespace vdrlive
 {
@@ -36,18 +35,18 @@ namespace vdrlive
 	{
 	}
 
-	const string EpgInfo::CurrentTime(const char* format) const
+	const std::string EpgInfo::CurrentTime(const char* format) const
 	{
 		return FormatDateTime(format, time(0));
 	}
 
-	const string EpgInfo::StartTime(const char* format) const
+	const std::string EpgInfo::StartTime(const char* format) const
 	{
 		time_t start = GetStartTime();
 		return start ? FormatDateTime(format, start) : "";
 	}
 
-	const string EpgInfo::EndTime(const char* format) const
+	const std::string EpgInfo::EndTime(const char* format) const
 	{
 		time_t end = GetEndTime();
 		return end ? FormatDateTime(format, end) : "";
@@ -85,7 +84,7 @@ namespace vdrlive
 	 * -------------------------------------------------------------------------
 	 */
 
-	EpgString::EpgString(const string& id, const string& caption, const string& info) :
+	EpgString::EpgString(const std::string& id, const std::string& caption, const std::string& info) :
 		EpgInfo(id, caption),
 		m_info(info)
 	{
@@ -95,17 +94,17 @@ namespace vdrlive
 	{
 	}
 
-	const string EpgString::Title() const
+	const std::string EpgString::Title() const
 	{
 		return m_info;
 	}
 
-	const string EpgString::ShortDescr() const
+	const std::string EpgString::ShortDescr() const
 	{
 		return "";
 	}
 
-	const string EpgString::LongDescr() const
+	const std::string EpgString::LongDescr() const
 	{
 		return "";
 	}
@@ -126,7 +125,7 @@ namespace vdrlive
 	 * -------------------------------------------------------------------------
 	 */
 
-	EpgRecording::EpgRecording(const string& recid, const cRecording* recording, const char* caption) :
+	EpgRecording::EpgRecording(const std::string& recid, const cRecording* recording, const char* caption) :
 		EpgInfo(recid, (caption != 0) ? caption : ""),
 		m_recording(recording),
 		m_ownCaption(caption != 0),
@@ -140,7 +139,7 @@ namespace vdrlive
 		m_recording = 0;
 	}
 
-	const string EpgRecording::Caption() const
+	const std::string EpgRecording::Caption() const
 	{
 		if (m_ownCaption) {
 			return EpgInfo::Caption();
@@ -152,7 +151,7 @@ namespace vdrlive
 		return Name();
 	}
 
-	const string EpgRecording::Title() const
+	const std::string EpgRecording::Title() const
 	{
 		if (!m_recording) {
 			return "";
@@ -162,19 +161,19 @@ namespace vdrlive
 		return (info && info->Title()) ? info->Title() : Name();
 	}
 
-	const string EpgRecording::ShortDescr() const
+	const std::string EpgRecording::ShortDescr() const
 	{
 		const cRecordingInfo* info = m_recording ? m_recording->Info() : 0;
 		return (info && info->ShortText()) ? info->ShortText() : "";
 	}
 
-	const string EpgRecording::LongDescr() const
+	const std::string EpgRecording::LongDescr() const
 	{
 		const cRecordingInfo* info = m_recording ? m_recording->Info() : 0;
 		return (info && info->Description()) ? info->Description() : "";
 	}
 
-	const string EpgRecording::Archived() const
+	const std::string EpgRecording::Archived() const
 	{
 		if (!m_checkedArchived && m_recording) {
 			m_archived = RecordingsManager::GetArchiveDescr(m_recording);
@@ -183,7 +182,7 @@ namespace vdrlive
 		return m_archived;
 	}
 
-	const string EpgRecording::FileName() const
+	const std::string EpgRecording::FileName() const
 	{
 		return m_recording->FileName();
 	}
@@ -223,11 +222,11 @@ namespace vdrlive
 		return 0;
 	}
 
-	const string EpgRecording::Name() const
+	const std::string EpgRecording::Name() const
 	{
-		string name(m_recording->Name());
+		std::string name(m_recording->Name());
 		size_t index = name.find_last_of('~');
-		if (index != string::npos) {
+		if (index != std::string::npos) {
 			name = name.substr(index+1);
 		}
 		return name;
@@ -255,10 +254,10 @@ namespace vdrlive
 	 * -------------------------------------------------------------------------
 	 */
 	namespace EpgEvents {
-		string EncodeDomId(tChannelID const &chanId, tEventID const &eId)
+		std::string EncodeDomId(tChannelID const &chanId, tEventID const &eId)
 		{
-			string channelId(chanId.ToString());
-			string eventId("event_");
+			std::string channelId(chanId.ToString());
+			std::string eventId("event_");
 
 			channelId = vdrlive::EncodeDomId(channelId, ".-", "pm");
 
@@ -268,24 +267,24 @@ namespace vdrlive
 			return eventId;
 		}
 
-		void DecodeDomId(string const &epgid, tChannelID& channelId, tEventID& eventId)
+		void DecodeDomId(std::string const &epgid, tChannelID& channelId, tEventID& eventId)
 		{
-			string const eventStr("event_");
+			std::string const eventStr("event_");
 
 			size_t delimPos = epgid.find_last_of('_');
-			string cIdStr = epgid.substr(eventStr.length(), delimPos - eventStr.length());
+			std::string cIdStr = epgid.substr(eventStr.length(), delimPos - eventStr.length());
 
 			cIdStr = vdrlive::DecodeDomId(cIdStr, "mp", "-.");
 
-			string const eIdStr = epgid.substr(delimPos+1);
+			std::string const eIdStr = epgid.substr(delimPos+1);
 
 			channelId = tChannelID::FromString(cIdStr.c_str());
 			eventId = lexical_cast<tEventID>(eIdStr);
 		}
 
-		EpgInfoPtr CreateEpgInfo(string const &epgid, cSchedules const *schedules)
+		EpgInfoPtr CreateEpgInfo(std::string const &epgid, cSchedules const *schedules)
 		{
-			string const errorInfo(tr("Epg error"));
+			std::string const errorInfo(tr("Epg error"));
 
 			tEventID eventId = tEventID();
 			tChannelID channelId = tChannelID();
@@ -316,36 +315,36 @@ namespace vdrlive
 			assert(chan);
 
 			if (event) {
-				string domId(idOverride ? idOverride : EncodeDomId(chan->GetChannelID(), event->EventID()));
+				std::string domId(idOverride ? idOverride : EncodeDomId(chan->GetChannelID(), event->EventID()));
 				return EpgInfoPtr(new EpgEvent(domId, event, chan->Name()));
 			}
 			if (LiveSetup().GetShowChannelsWithoutEPG()) {
-				string domId(idOverride ? idOverride : EncodeDomId(chan->GetChannelID(), 0));
+				std::string domId(idOverride ? idOverride : EncodeDomId(chan->GetChannelID(), 0));
 				return EpgInfoPtr(new EmptyEvent(domId, chan->GetChannelID(), chan->Name()));
 			}
 			return EpgInfoPtr();
 		}
 
-		EpgInfoPtr CreateEpgInfo(string const &recid, cRecording const *recording, char const *caption)
+		EpgInfoPtr CreateEpgInfo(std::string const &recid, cRecording const *recording, char const *caption)
 		{
 			return EpgInfoPtr(new EpgRecording(recid, recording, caption));
 		}
 
-		EpgInfoPtr CreateEpgInfo(string const &id, string const &caption, string const &info)
+		EpgInfoPtr CreateEpgInfo(std::string const &id, std::string const &caption, std::string const &info)
 		{
 			return EpgInfoPtr(new EpgString(id, caption, info));
 		}
 
 
-		bool ScanForEpgImages(string const & imageId, string const & wildcard, list<string> & images)
+		bool ScanForEpgImages(std::string const & imageId, std::string const & wildcard, std::list<std::string> & images)
 		{
 			bool found = false;
-			const string filemask(LiveSetup().GetEpgImageDir() + "/" + imageId + wildcard);
+			const std::string filemask(LiveSetup().GetEpgImageDir() + "/" + imageId + wildcard);
 			glob_t globbuf;
 			globbuf.gl_offs = 0;
 			if (!LiveSetup().GetEpgImageDir().empty() && glob(filemask.c_str(), GLOB_DOOFFS, NULL, &globbuf) == 0) {
 				for(size_t i = 0; i < globbuf.gl_pathc; i++) {
-					const string imagefile(globbuf.gl_pathv[i]);
+					const std::string imagefile(globbuf.gl_pathv[i]);
 					size_t delimPos = imagefile.find_last_of('/');
 					images.push_back(imagefile.substr(delimPos+1));
 					found = true;
@@ -355,10 +354,10 @@ namespace vdrlive
 			return found;
 		}
 
-		bool ScanForRecImages(string const & imageId, string const & recfolder , list<string> & images)
+		bool ScanForRecImages(std::string const & imageId, std::string const & recfolder , std::list<std::string> & images)
 		{
 			bool found = false;
-			const string filetypes[] = {"png", "jpg", "PNG", "JPG"};
+			const std::string filetypes[] = {"png", "jpg", "PNG", "JPG"};
 			int size = sizeof(filetypes)/sizeof(filetypes[0]);
 
 			if (recfolder.empty()) {
@@ -368,20 +367,20 @@ namespace vdrlive
 
 			for (int j = 0;j < size;j++)
 			{
-				const string filemask(recfolder + "/*." + filetypes[j]);
+				const std::string filemask(recfolder + "/*." + filetypes[j]);
 				glob_t globbuf;
 				globbuf.gl_offs = 0;
 				if (glob(filemask.c_str(), GLOB_DOOFFS, NULL, &globbuf) == 0) {
 					for(size_t i = 0; i < globbuf.gl_pathc; i++) {
-						const string imagefile(globbuf.gl_pathv[i]);
-						const string imagecopy(imagefile);
+						const std::string imagefile(globbuf.gl_pathv[i]);
+						const std::string imagecopy(imagefile);
 
 						size_t delimPos = imagefile.find_last_of('/');
 						images.push_back(imagefile.substr(delimPos+1));
 
 						// create a temporary symlink of the image in /tmp
-						const string imagename(imagefile.substr(delimPos+1));
-						const string tmpfile("/tmp/" + imageId + "_" + imagename);
+						const std::string imagename(imagefile.substr(delimPos+1));
+						const std::string tmpfile("/tmp/" + imageId + "_" + imagename);
 
 						char cmdBuff[500];
 						sprintf(cmdBuff,"ln -s \"%s\" \"%s\"",imagefile.c_str(),tmpfile.c_str());
@@ -396,12 +395,12 @@ namespace vdrlive
 			return found;
 		}
 
-		list<string> EpgImages(string const &epgid)
+		std::list<std::string> EpgImages(std::string const &epgid)
 		{
 			size_t delimPos = epgid.find_last_of('_');
-			string imageId = epgid.substr(delimPos+1);
+			std::string imageId = epgid.substr(delimPos+1);
 
-			list<string> images;
+			std::list<std::string> images;
 
 			// Initially we scan for images that follow the scheme
 			// '<epgid>_<distinction>.*' where distincition is any
@@ -438,12 +437,12 @@ namespace vdrlive
 			return images;
 		}
 
-		list<string> RecImages(string const &epgid, string const &recfolder)
+		std::list<std::string> RecImages(std::string const &epgid, std::string const &recfolder)
 		{
 			size_t delimPos = epgid.find_last_of('_');
-			string imageId = epgid.substr(delimPos+1);
+			std::string imageId = epgid.substr(delimPos+1);
 
-			list<string> images;
+			std::list<std::string> images;
 			// Scan for all images in recording directory
 			ScanForRecImages(imageId, recfolder, images);
 			return images;

--- a/epgsearch.cpp
+++ b/epgsearch.cpp
@@ -10,14 +10,12 @@
 
 namespace vdrlive {
 
-using namespace std;
-
 static char ServiceInterface[] = "Epgsearch-services-v1.0";
 
 bool operator<( SearchTimer const& left, SearchTimer const& right )
 {
-   string leftlower = left.m_search;
-   string rightlower = right.m_search;
+   std::string leftlower = left.m_search;
+   std::string rightlower = right.m_search;
    std::transform(leftlower.begin(), leftlower.end(), leftlower.begin(), (int(*)(int)) tolower);
    std::transform(rightlower.begin(), rightlower.end(), rightlower.begin(), (int(*)(int)) tolower);
    return leftlower < rightlower;
@@ -29,7 +27,7 @@ bool CheckEpgsearchVersion()
 	const Features< features::epgsearch >& f = LiveFeatures< features::epgsearch >();
 	if ( f.Loaded() ) {
 		if ( !f.Recent() )
-			throw HtmlError( tr("Required minimum version of epgsearch: ") + string( f.MinVersion() ));
+			throw HtmlError( tr("Required minimum version of epgsearch: ") + std::string( f.MinVersion() ));
 		return true;
 	}
 	return false;
@@ -89,12 +87,12 @@ void SearchTimer::Init()
 	m_ignoreMissingEPGCats = false;
 }
 
-SearchTimer::SearchTimer( string const& data )
+SearchTimer::SearchTimer( std::string const& data )
 {
    Init();
-   vector< string > parts = StringSplit( data, ':' );
+   std::vector<std::string> parts = StringSplit( data, ':' );
    try {
-      vector< string >::const_iterator part = parts.begin();
+      std::vector<std::string>::const_iterator part = parts.begin();
       for ( int i = 0; part != parts.end(); ++i, ++part ) {
 			switch ( i ) {
 			case  0: m_id = lexical_cast< int >( *part ); break;
@@ -170,20 +168,20 @@ std::string SearchTimer::ToText()
 
    if (m_useTime)
    {
-      ostringstream os;
-      os << setw(4) << setfill('0') << m_startTime;
+      std::stringstream os;
+      os << std::setw(4) << std::setfill('0') << m_startTime;
       tmp_Start = os.str();
       os.str("");
-      os << setw(4) << setfill('0') << m_stopTime;
+      os << std::setw(4) << std::setfill('0') << m_stopTime;
       tmp_Stop = os.str();
    }
    if (m_useDuration)
    {
-      ostringstream os;
-      os << setw(4) << setfill('0') << m_minDuration;
+      std::stringstream os;
+      os << std::setw(4) << std::setfill('0') << m_minDuration;
       tmp_minDuration = os.str();
       os.str("");
-      os << setw(4) << setfill('0') << m_maxDuration;
+      os << std::setw(4) << std::setfill('0') << m_maxDuration;
       tmp_maxDuration = os.str();
    }
 
@@ -219,7 +217,7 @@ std::string SearchTimer::ToText()
          tmp_blacklists += (tmp_blacklists != ""?"|":"") +  m_blacklistIDs[i];
    }
 
-   ostringstream os;
+   std::stringstream os;
    os << m_id << ":"
       << tmp_search << ":"
       << (m_useTime?1:0) << ":"
@@ -274,7 +272,7 @@ std::string SearchTimer::ToText()
    return os.str();
 }
 
-void SearchTimer::ParseChannel( string const& data )
+void SearchTimer::ParseChannel( std::string const& data )
 {
 	switch ( m_useChannel ) {
 	case NoChannel: m_channels = tr("All"); break;
@@ -284,9 +282,9 @@ void SearchTimer::ParseChannel( string const& data )
 	}
 }
 
-void SearchTimer::ParseChannelIDs( string const& data )
+void SearchTimer::ParseChannelIDs( std::string const& data )
 {
-	vector< string > parts = StringSplit( data, '|' );
+	std::vector<std::string> parts = StringSplit( data, '|' );
 	m_channelMin = lexical_cast< tChannelID >( parts[ 0 ] );
 
 #if VDRVERSNUM >= 20301
@@ -309,37 +307,37 @@ void SearchTimer::ParseChannelIDs( string const& data )
 	channel = Channels.GetByChannelID( m_channelMax );
 #endif
 	if ( channel != 0 )
-		m_channels += string( " - " ) + channel->Name();
+		m_channels += std::string( " - " ) + channel->Name();
 }
 
-void SearchTimer::ParseExtEPGInfo( string const& data )
+void SearchTimer::ParseExtEPGInfo( std::string const& data )
 {
    m_ExtEPGInfo = StringSplit( data, '|' );
 }
 
-void SearchTimer::ParseBlacklist( string const& data )
+void SearchTimer::ParseBlacklist( std::string const& data )
 {
    m_blacklistIDs = StringSplit( data, '|' );
 }
 
-string SearchTimer::StartTimeFormatted()
+std::string SearchTimer::StartTimeFormatted()
 {
 	time_t start = cTimer::SetTime(time(NULL), (((StartTime() / 100 ) % 100) * 60 * 60) + (StartTime() % 100 * 60));
 	return FormatDateTime(tr("%I:%M %p"), start);
 }
 
-string SearchTimer::StopTimeFormatted()
+std::string SearchTimer::StopTimeFormatted()
 {
 	time_t stop = cTimer::SetTime(time(NULL), (((StopTime() / 100 ) % 100) * 60 * 60) + (StopTime() % 100 * 60));
 	return FormatDateTime(tr("%I:%M %p"), stop);
 }
 
-string SearchTimer::UseAsSearchTimerFrom(string const& format)
+std::string SearchTimer::UseAsSearchTimerFrom(std::string const& format)
 {
 	return DatePickerToC(m_useAsSearchTimerFrom, format);
 }
 
-string SearchTimer::UseAsSearchTimerTil(string const& format)
+std::string SearchTimer::UseAsSearchTimerTil(std::string const& format)
 {
 	return DatePickerToC(m_useAsSearchTimerTil, format);
 }
@@ -371,7 +369,7 @@ bool SearchTimers::Reload()
 #else
 	ReadLock channelsLock( Channels, 0 );
 #endif
-	list< string > timers = service.handler->SearchTimerList();
+	std::list<std::string> timers = service.handler->SearchTimerList();
 	m_timers.assign( timers.begin(), timers.end() );
 	m_timers.sort();
 	return true;
@@ -447,14 +445,14 @@ bool SearchTimer::BlacklistSelected(int id) const
    return false;
 }
 
-ExtEPGInfo::ExtEPGInfo( string const& data )
+ExtEPGInfo::ExtEPGInfo( std::string const& data )
 {
    m_id = -1;
    m_searchmode = 0;
 
-   vector< string > parts = StringSplit( data, '|' );
+   std::vector<std::string> parts = StringSplit( data, '|' );
    try {
-      vector< string >::const_iterator part = parts.begin();
+      std::vector<std::string>::const_iterator part = parts.begin();
       for ( int i = 0; part != parts.end(); ++i, ++part ) {
          switch ( i ) {
 			case  0: m_id = lexical_cast< int >( *part ); break;
@@ -468,7 +466,7 @@ ExtEPGInfo::ExtEPGInfo( string const& data )
    }
 }
 
-void ExtEPGInfo::ParseValues( string const& data )
+void ExtEPGInfo::ParseValues( std::string const& data )
 {
    m_values = StringSplit( data, ',' );
 }
@@ -476,9 +474,9 @@ void ExtEPGInfo::ParseValues( string const& data )
 bool ExtEPGInfo::Selected(unsigned int index, std::string const& values)
 {
    if (index >= m_values.size()) return false;
-   string extepgvalue = StringTrim(m_values[index]);
+   std::string extepgvalue = StringTrim(m_values[index]);
 
-   vector< string > parts;
+   std::vector<std::string> parts;
    parts = StringSplit( values, ',' );
    for(unsigned int i=0; i<parts.size(); i++) if (StringTrim(parts[i]) == extepgvalue) return true;
    parts = StringSplit( values, ';' );
@@ -496,15 +494,15 @@ ExtEPGInfos::ExtEPGInfos()
 	if ( !CheckEpgsearchVersion() || cPluginManager::CallFirstService(ServiceInterface, &service) == 0 )
 		throw HtmlError( tr("EPGSearch version outdated! Please update.") );
 
-	list< string > infos = service.handler->ExtEPGInfoList();
+	std::list<std::string> infos = service.handler->ExtEPGInfoList();
 	m_infos.assign( infos.begin(), infos.end() );
 }
 
-ChannelGroup::ChannelGroup( string const& data )
+ChannelGroup::ChannelGroup( std::string const& data )
 {
-   vector< string > parts = StringSplit( data, '|' );
+   std::vector<std::string> parts = StringSplit( data, '|' );
    try {
-      vector< string >::const_iterator part = parts.begin();
+      std::vector<std::string>::const_iterator part = parts.begin();
       for ( int i = 0; part != parts.end(); ++i, ++part ) {
          switch ( i ) {
 			case  0: m_name = *part; break;
@@ -520,15 +518,15 @@ ChannelGroups::ChannelGroups()
 	if ( !CheckEpgsearchVersion() || cPluginManager::CallFirstService(ServiceInterface, &service) == 0 )
 		throw HtmlError( tr("EPGSearch version outdated! Please update.") );
 
-	list< string > list = service.handler->ChanGrpList();
+	std::list<std::string> list = service.handler->ChanGrpList();
 	m_list.assign( list.begin(), list.end() );
 }
 
-Blacklist::Blacklist( string const& data )
+Blacklist::Blacklist( std::string const& data )
 {
-   vector< string > parts = StringSplit( data, ':' );
+   std::vector<std::string> parts = StringSplit( data, ':' );
    try {
-      vector< string >::const_iterator part = parts.begin();
+      std::vector<std::string>::const_iterator part = parts.begin();
       for ( int i = 0; part != parts.end(); ++i, ++part ) {
 			switch ( i ) {
 			case  0: m_id = lexical_cast< int >( *part ); break;
@@ -545,16 +543,16 @@ Blacklists::Blacklists()
 	if ( !CheckEpgsearchVersion() || cPluginManager::CallFirstService(ServiceInterface, &service) == 0 )
 		throw HtmlError( tr("EPGSearch version outdated! Please update.") );
 
-	list< string > list = service.handler->BlackList();
+	std::list<std::string> list = service.handler->BlackList();
 	m_list.assign( list.begin(), list.end() );
     m_list.sort();
 }
 
-SearchResult::SearchResult( string const& data )
+SearchResult::SearchResult( std::string const& data )
 {
-	vector< string > parts = StringSplit( data, ':' );
+	std::vector<std::string> parts = StringSplit( data, ':' );
 	try {
-		vector< string >::const_iterator part = parts.begin();
+		std::vector<std::string>::const_iterator part = parts.begin();
 		for ( int i = 0; part != parts.end(); ++i, ++part ) {
 			switch ( i ) {
 			case  0: m_searchId = lexical_cast< int >( *part ); break;
@@ -600,7 +598,7 @@ void SearchResults::GetByID(int id)
 	if ( !CheckEpgsearchVersion() || cPluginManager::CallFirstService(ServiceInterface, &service) == 0 )
 		throw HtmlError( tr("EPGSearch version outdated! Please update.") );
 
-	list< string > list = service.handler->QuerySearchTimer(id);
+	std::list<std::string> list = service.handler->QuerySearchTimer(id);
 	m_list.assign( list.begin(), list.end() );
     m_list.sort();
 }
@@ -611,7 +609,7 @@ void SearchResults::GetByQuery(std::string const& query)
 	if ( !CheckEpgsearchVersion() || cPluginManager::CallFirstService(ServiceInterface, &service) == 0 )
 		throw HtmlError( tr("EPGSearch version outdated! Please update.") );
 
-	list< string > list = service.handler->QuerySearch(query);
+	std::list<std::string> list = service.handler->QuerySearch(query);
 	m_list.assign( list.begin(), list.end() );
 	m_list.sort();
 }

--- a/ffmpeg.cpp
+++ b/ffmpeg.cpp
@@ -15,8 +15,6 @@
 
 namespace vdrlive {
 
-using namespace std;
-
 
 FFmpegThread::FFmpegThread()
 	:cThread("stream utility handler")
@@ -65,31 +63,31 @@ void FFmpegThread::Action()
 
 	std::string def = "ffmpeg -loglevel warning -f mpegts -analyzeduration 1.2M -probesize 5M "
 		"-i <input> -map 0:v -map 0:a:0 -c:v copy -c:a aac -ac 2";
-	vector<string> vopts;
+	std::vector<std::string> vopts;
 	vopts.push_back( LiveSetup().GetStreamVideoOpt0() );
 	vopts.push_back( LiveSetup().GetStreamVideoOpt1() );
 	vopts.push_back( LiveSetup().GetStreamVideoOpt2() );
 	vopts.push_back( LiveSetup().GetStreamVideoOpt3() );
 
-	if (vopts[0].empty() || vopts[0].find("<input>") == string::npos) { // h264
+	if (vopts[0].empty() || vopts[0].find("<input>") == std::string::npos) { // h264
 		vopts[0] = def;
 		LiveSetup().SetStreamVideoOpt0(vopts[0]);
 	}
-	if (vopts[1].empty() || vopts[1].find("<input>") == string::npos) { // h265
+	if (vopts[1].empty() || vopts[1].find("<input>") == std::string::npos) { // h265
 		vopts[1] = def;
 		LiveSetup().SetStreamVideoOpt1(vopts[1]);
 	}
-	if (vopts[2].empty() || vopts[2].find("<input>") == string::npos) { // mpeg2
+	if (vopts[2].empty() || vopts[2].find("<input>") == std::string::npos) { // mpeg2
 		vopts[2] = def;
 		LiveSetup().SetStreamVideoOpt2(vopts[2]);
 	}
-	if (vopts[3].empty() || vopts[3].find("<input>") == string::npos) { // others
+	if (vopts[3].empty() || vopts[3].find("<input>") == std::string::npos) { // others
 		vopts[3] = def;
 		LiveSetup().SetStreamVideoOpt3(vopts[3]);
 	}
 
-	string packerCmd(vopts[vOption]);
-	stringstream ss;
+	std::string packerCmd(vopts[vOption]);
+	std::stringstream ss;
 	ss.str("");
 	ss << "\"http://localhost:" << LiveSetup().GetStreamdevPort() << "/" << targetChannel << "\"";
 	packerCmd.replace(packerCmd.find("<input>"), 7, ss.str());
@@ -121,7 +119,7 @@ void FFmpegThread::Action()
 			count = 0;
 			do {
 				cw.Wait(1000);
-				ifstream f(ss.str().c_str());
+				std::ifstream f(ss.str().c_str());
 				if (f.good()) break; // check if ffmpeg starts to generate output
 				dsyslog("Live: FFmpegTread::Action() ffmpeg starting... %d", count);
 			} while (Running() && pp.Check() == 0 && ++count < 6);
@@ -155,7 +153,7 @@ void FFmpegThread::Action()
 		int r = pp.Close();
 		dsyslog("Live: FFmpegTread::Action::Close(%d) disabled ffmpeg", r);
 
-	} catch (exception const& ex) {
+	} catch (std::exception const& ex) {
 		esyslog("ERROR: live FFmpegTread::Action() failed: %s", ex.what());
 	}
 	dsyslog("Live: FFmpegTread::Action() finished");

--- a/grab.cpp
+++ b/grab.cpp
@@ -7,8 +7,6 @@
 
 namespace vdrlive {
 
-using namespace std;
-
 const unsigned int GrabMinIntervalMs = 500;
 const unsigned int GrabPauseIntervalMs = GrabMinIntervalMs * 20;
 
@@ -89,7 +87,7 @@ GrabImageInfo GrabImageManager::GetImage() const
 {
 	cMutexLock lock( &LiveTaskManager() );
 	m_task->Activate();
-	return make_pair( m_image, m_size );
+	return std::make_pair( m_image, m_size );
 }
 
 bool GrabImageManager::CanGrab() const

--- a/livefeatures.cpp
+++ b/livefeatures.cpp
@@ -5,19 +5,17 @@
 
 namespace vdrlive {
 
-using namespace std;
-
-SplitVersion::SplitVersion( string version )
+SplitVersion::SplitVersion( std::string version )
 	: m_version( 0 )
 {
 	static const int factors[] = { 100000000, 1000000, 1000, 1 };
 
 	size_t pos = version.find('-');
-	if ( pos != string::npos ) {
+	if ( pos != std::string::npos ) {
 		m_suffix = version.substr( pos + 1 );
 		version.erase( pos );
 	}
-	vector< string > parts = StringSplit( version, '.' );
+	std::vector<std::string> parts = StringSplit( version, '.' );
 	for ( size_t i = 0; i < parts.size() && i < sizeof(factors)/sizeof(factors[0]); ++i ) {
 		m_version += atoi( parts[ i ].c_str() ) * factors[ i ];
 	}

--- a/preload.cpp
+++ b/preload.cpp
@@ -5,7 +5,6 @@
 
 #include <vdr/tools.h>
 
-using namespace std;
 
 namespace vdrlive {
 
@@ -13,7 +12,7 @@ namespace vdrlive {
 // (cd live; find * -type f ! -wholename '*CVS*' ! -wholename '*themes*' ! -name '*~' ! -name '.*') | awk '{print "\"" $1 "\","}'}
 // and clean out unneeded entries.
 
-	void PreLoadFileCache(string const& configDir)
+	void PreLoadFileCache(std::string const& configDir)
 	{
 		static char const * const preloadFiles[] = {
 			"css/siteprefs.css",

--- a/setup.cpp
+++ b/setup.cpp
@@ -20,8 +20,6 @@
 
 namespace vdrlive {
 
-using namespace std;
-
 Setup::Setup():
 		m_serverPort( 8008 ),
 		m_serverSslPort( 8443 ),
@@ -95,7 +93,7 @@ bool Setup::ParseCommandLine( int argc, char* argv[] )
 char const* Setup::CommandLineHelp() const
 {
 	if ( m_helpString.empty() ) {
-		ostringstream builder;
+		std::stringstream builder;
 		builder << "  -p PORT,  --port=PORT        use PORT to listen for incoming connections\n"
 				   "                               (default: " << m_serverPort << ")\n"
 				<< "  -i IP,    --ip=IP            bind server only to specified IP, may appear\n"
@@ -147,9 +145,9 @@ bool Setup::ParseSetupEntry( char const* name, char const* value )
 
 bool Setup::CheckServerPort()
 {
-	if ( m_serverPort <= 0 || m_serverPort > numeric_limits< uint16_t >::max() ) {
+	if ( m_serverPort <= 0 || m_serverPort > std::numeric_limits<uint16_t>::max() ) {
 		esyslog( "live: ERROR: server port %d is not a valid port number", m_serverPort );
-		cerr << "ERROR: live server port " << m_serverPort << " is not a valid port number" << endl;
+		std::cerr << "ERROR: live server port " << m_serverPort << " is not a valid port number" << std::endl;
 		return false;
 	}
 	return true;
@@ -157,9 +155,9 @@ bool Setup::CheckServerPort()
 
 bool Setup::CheckServerSslPort()
 {
-	if ( m_serverSslPort <= 0 || m_serverSslPort > numeric_limits< uint16_t >::max() ) {
+	if ( m_serverSslPort <= 0 || m_serverSslPort > std::numeric_limits<uint16_t>::max() ) {
 		esyslog( "live: ERROR: server ssl port %d is not a valid port number", m_serverSslPort );
-		cerr << "ERROR: live server ssl port " << m_serverSslPort << " is not a valid port number" << endl;
+		std::cerr << "ERROR: live server ssl port " << m_serverSslPort << " is not a valid port number" << std::endl;
 		return false;
 	}
 	return true;
@@ -168,18 +166,18 @@ bool Setup::CheckServerSslPort()
 namespace {
 	struct IpValidator
 	{
-		bool operator() (string const & ip)
+		bool operator() (std::string const & ip)
 		{
 			struct in6_addr buf;
 			struct in_addr buf4;
 
 			esyslog( "live: INFO: validating server ip '%s'", ip.c_str());
-			cerr << "INFO: validating live server ip '" << ip << "'" << endl;
+			std::cerr << "INFO: validating live server ip '" << ip << "'" << std::endl;
 			bool valid = inet_aton(ip.c_str(), &buf4) || inet_pton(AF_INET6, ip.c_str(), &buf);
 
 			if (!valid) {
 				esyslog( "live: ERROR: server ip %s is not a valid ip address", ip.c_str());
-				cerr << "ERROR: live server ip '" << ip << "' is not a valid ip address" << endl;
+				std::cerr << "ERROR: live server ip '" << ip << "' is not a valid ip address" << std::endl;
 			}
 			return valid;
 		}
@@ -225,20 +223,20 @@ bool Setup::CheckServerIps()
 std::string const Setup::GetMD5HashAdminPassword() const
 {
 	// format is <length>:<md5-hash of password>
-	vector< string > parts = StringSplit( m_adminPasswordMD5, ':' );
+	std::vector<std::string> parts = StringSplit( m_adminPasswordMD5, ':' );
 	return (parts.size() > 1) ? parts[1] : "";
 }
 
 int Setup::GetAdminPasswordLength() const
 {
 	// format is <length>:<md5-hash of password>
-	vector< string > parts = StringSplit( m_adminPasswordMD5, ':' );
+	std::vector<std::string> parts = StringSplit( m_adminPasswordMD5, ':' );
 	return (parts.size() > 0) ? lexical_cast< int >( parts[0] ) : 0;
 }
 
 std::string Setup::SetAdminPassword(std::string password)
 {
-	ostringstream passwordStr;
+	std::stringstream passwordStr;
 	passwordStr << password.size() << ":" << MD5Hash(password);
 	m_adminPasswordMD5 = passwordStr.str();
 	return m_adminPasswordMD5;
@@ -268,34 +266,34 @@ bool Setup::UseAuth() const
 bool Setup::CheckLocalNet(const std::string& ip)
 {
 	// split local net mask in net and range
-	vector< string > parts = StringSplit( m_localnetmask, '/' );
+	std::vector<std::string> parts = StringSplit( m_localnetmask, '/' );
 	if (parts.size() != 2) return false;
-	string net = parts[0];
+	std::string net = parts[0];
 
-	int range = lexical_cast< int >(parts[1]);
+	int range = lexical_cast<int>(parts[1]);
 	// split net and ip addr in its 4 subcomponents
-	vector< string > netparts = StringSplit( net, '.' );
-	vector< string > addrparts = StringSplit( ip, '.' );
+	std::vector<std::string> netparts = StringSplit( net, '.' );
+	std::vector<std::string> addrparts = StringSplit( ip, '.' );
 	if (netparts.size() != 4 || addrparts.size() != 4) return false;
 
 	// to binary representation
-	ostringstream bin_netstream;
-	bin_netstream << bitset<8>(lexical_cast<long>(netparts[0]))
-		<< bitset<8>(lexical_cast<long>(netparts[1]))
-		<< bitset<8>(lexical_cast<long>(netparts[2]))
-		<< bitset<8>(lexical_cast<long>(netparts[3]));
+	std::stringstream bin_netstream;
+	bin_netstream << std::bitset<8>(lexical_cast<long>(netparts[0]))
+		<< std::bitset<8>(lexical_cast<long>(netparts[1]))
+		<< std::bitset<8>(lexical_cast<long>(netparts[2]))
+		<< std::bitset<8>(lexical_cast<long>(netparts[3]));
 
-	ostringstream bin_addrstream;
-	bin_addrstream << bitset<8>(lexical_cast<long>(addrparts[0]))
-		<< bitset<8>(lexical_cast<long>(addrparts[1]))
-		<< bitset<8>(lexical_cast<long>(addrparts[2]))
-		<< bitset<8>(lexical_cast<long>(addrparts[3]));
+	std::stringstream bin_addrstream;
+	bin_addrstream << std::bitset<8>(lexical_cast<long>(addrparts[0]))
+		<< std::bitset<8>(lexical_cast<long>(addrparts[1]))
+		<< std::bitset<8>(lexical_cast<long>(addrparts[2]))
+		<< std::bitset<8>(lexical_cast<long>(addrparts[3]));
 
 	// compare range
-	string bin_net = bin_netstream.str();
-	string bin_addr = bin_addrstream.str();
-	string bin_net_range(bin_net.begin(), bin_net.begin() + range);
-	string addr_net_range(bin_addr.begin(), bin_addr.begin() + range);
+	std::string bin_net = bin_netstream.str();
+	std::string bin_addr = bin_addrstream.str();
+	std::string bin_net_range(bin_net.begin(), bin_net.begin() + range);
+	std::string addr_net_range(bin_addr.begin(), bin_addr.begin() + range);
 	m_islocalnet = (bin_net_range == addr_net_range);
 
 	return m_islocalnet;
@@ -352,7 +350,7 @@ cMenuSetupLive::cMenuSetupLive():
 
 	m_oldpasswordMD5 = m_newpasswordMD5 = vdrlive::LiveSetup().GetMD5HashAdminPassword();
 
-	string strHidden(vdrlive::LiveSetup().GetAdminPasswordLength(), '*');
+	std::string strHidden(vdrlive::LiveSetup().GetAdminPasswordLength(), '*');
 	strn0cpy(m_tmpPassword, strHidden.c_str(), sizeof(m_tmpPassword));
 	strcpy(m_adminPassword, "");
 	Set();
@@ -415,7 +413,7 @@ eOSState cMenuSetupLive::ProcessKey(eKeys Key)
 	{
 		strcpy(m_adminPassword, m_tmpPassword);
 		m_newpasswordMD5 = MD5Hash(m_tmpPassword);
-		string strHidden(strlen(m_adminPassword), '*');
+		std::string strHidden(strlen(m_adminPassword), '*');
 		strcpy(m_tmpPassword, strHidden.c_str());
 		Set();
 		Display();

--- a/thread.cpp
+++ b/thread.cpp
@@ -7,7 +7,6 @@
 
 namespace vdrlive {
 
-using namespace std;
 using namespace tnt;
 
 
@@ -35,10 +34,10 @@ void ServerThread::Action()
 		TntConfig::Get().Configure(*m_server);
 		m_server->run();
 		m_server.reset(0);
-	} catch (exception const& ex) {
+	} catch (std::exception const& ex) {
 		// XXX move initial error handling to live.cpp
 		esyslog("live: ERROR: live httpd server crashed: %s", ex.what());
-		cerr << "HTTPD FATAL ERROR: " << ex.what() << endl;
+		std::cerr << "HTTPD FATAL ERROR: " << ex.what() << std::endl;
 		//cThread::EmergencyExit(true);
 	}
 }

--- a/timerconflict.cpp
+++ b/timerconflict.cpp
@@ -14,8 +14,6 @@ namespace vdrlive {
 
 	bool CheckEpgsearchVersion();
 
-	using namespace std;
-
 	static char ServiceInterface[] = "Epgsearch-services-v1.1";
 
 	bool operator<( TimerConflict const& left, TimerConflict const& right )
@@ -33,26 +31,26 @@ namespace vdrlive {
 		conflictTime = 0;
 	}
 
-	TimerConflict::TimerConflict( string const& data )
+	TimerConflict::TimerConflict( std::string const& data )
 	{
 		Init();
 //		dsyslog("live: TimerConflict() data '%s'", data.c_str());
-		vector< string > parts = StringSplit( data, ':' );
+		std::vector<std::string> parts = StringSplit( data, ':' );
 		try {
-			vector< string >::const_iterator part = parts.begin();
+			std::vector<std::string>::const_iterator part = parts.begin();
 			if (parts.size() > 0) {
 				conflictTime = lexical_cast< time_t >( *part++ );
 				for ( int i = 1; part != parts.end(); ++i, ++part ) {
-					vector< string > timerparts = StringSplit( *part, '|' );
-					vector< string >::const_iterator timerpart = timerparts.begin();
+					std::vector<std::string> timerparts = StringSplit( *part, '|' );
+					std::vector<std::string>::const_iterator timerpart = timerparts.begin();
 					TimerInConflict timer;
 					for ( int j = 0; timerpart != timerparts.end(); ++j, ++timerpart ) {
 						switch (j) {
 							case 0: timer.timerIndex = lexical_cast< int >( *timerpart ); break;
 							case 1: timer.percentage = lexical_cast< int >( *timerpart ); break;
 							case 2: {
-								vector< string > conctimerparts = StringSplit( *timerpart, '#' );
-								vector< string >::const_iterator conctimerpart = conctimerparts.begin();
+								std::vector<std::string> conctimerparts = StringSplit( *timerpart, '#' );
+								std::vector<std::string>::const_iterator conctimerpart = conctimerparts.begin();
 								for ( int k = 0; conctimerpart != conctimerparts.end(); ++k, ++conctimerpart )
 									timer.concurrentTimerIndices.push_back(lexical_cast< int >( *conctimerpart ));
 								break;
@@ -79,7 +77,7 @@ namespace vdrlive {
 		    	cServiceHandler_v1_1* handler = dynamic_cast<cServiceHandler_v1_1*>(service.handler.get());
 		    	if (handler)
 		      	{
-				list< string > conflicts = service.handler->TimerConflictList();
+				std::list<std::string> conflicts = service.handler->TimerConflictList();
 //				for(std::list<std::string>::const_iterator i = conflicts.begin(); i != conflicts.end(); ++i) {
 //					dsyslog("live: TimerConflicts::TimerConflicts() conflicts '%s'",i->c_str());
 //				}
@@ -101,7 +99,7 @@ namespace vdrlive {
 	}
 
 
-	void TimerConflicts::GetRemote(std::list< std::string > & conflicts )
+	void TimerConflicts::GetRemote(std::list<std::string> & conflicts )
 	{
 		cStringList svdrpServerNames;
 
@@ -112,7 +110,7 @@ namespace vdrlive {
 			std::string remoteServer = svdrpServerNames[i];
 //			dsyslog("live: TimerConflicts::GetRemote() found remote server '%s'", remoteServer.c_str());
 			cStringList response;
-                        string command = "PLUG epgsearch lscc";
+                        std::string command = "PLUG epgsearch lscc";
                         bool svdrpOK = ExecSVDRPCommand(remoteServer.c_str(), command.c_str(), &response);
                         if ( !svdrpOK ) {
                                 esyslog("live: TimerConflicts::GetRemote() svdrp command '%s' on remote server '%s'failed", command.c_str(), remoteServer.c_str());
@@ -123,8 +121,8 @@ namespace vdrlive {
 //					dsyslog("live: GetRemote() response[i] '%s'", response[i]);
 					switch ( code ) {
                                         	case 900: {
-							string rConflict = response[i];
-							string remConflict = rConflict.substr(4);
+							std::string rConflict = response[i];
+							std::string remConflict = rConflict.substr(4);
 							remConflict.append("|");
 							remConflict.append(remoteServer);
 //							dsyslog("live: TimerConflicts::GetRemote() found remote conflict '%s' ", remConflict.c_str());

--- a/timers.cpp
+++ b/timers.cpp
@@ -18,8 +18,6 @@ static bool operator<( cTimer const& left, cTimer const& right )
 
 namespace vdrlive {
 
-	using namespace std;
-
 	static char const* const TIMER_DELETE = "DELETE";
 	static char const* const TIMER_TOGGLE = "TOGGLE";
 
@@ -31,17 +29,17 @@ namespace vdrlive {
 		ReloadTimers();
 	}
 
-	string SortedTimers::GetTimerId( cTimer const& timer )
+	std::string SortedTimers::GetTimerId( cTimer const& timer )
 	{
-		ostringstream builder;
+		std::stringstream builder;
 		builder << timer.Channel()->GetChannelID() << ":" << timer.WeekDays() << ":"
 				<< timer.Day() << ":" << timer.Start() << ":" << timer.Stop();
 		return builder.str();
 	}
 
-	const cTimer* SortedTimers::GetByTimerId( string const& timerid )
+	const cTimer* SortedTimers::GetByTimerId( std::string const& timerid )
 	{
-		vector< string > parts = StringSplit( timerid, ':' );
+		std::vector<std::string> parts = StringSplit( timerid, ':' );
 		if ( parts.size() < 5 ) {
 			esyslog("live: GetByTimerId: invalid format %s", timerid.c_str() );
 			return 0;
@@ -79,18 +77,18 @@ namespace vdrlive {
 	}
 
 
-	string SortedTimers::EncodeDomId(string const& timerid)
+	std::string SortedTimers::EncodeDomId(std::string const& timerid)
 	{
-		string tId("timer_");
+		std::string tId("timer_");
 		tId += vdrlive::EncodeDomId(timerid, ".-:", "pmc");
 		return tId;
 	}
 
-	string SortedTimers::DecodeDomId(string const &timerDomId)
+	std::string SortedTimers::DecodeDomId(std::string const &timerDomId)
 	{
-		string const timerStr("timer_");
+		std::string const timerStr("timer_");
 
-		string tId = timerDomId.substr(timerStr.length());
+		std::string tId = timerDomId.substr(timerStr.length());
 
 		return vdrlive::DecodeDomId(tId, "pmc", ".-:");
 	}
@@ -118,50 +116,50 @@ namespace vdrlive {
 		sort();
 	}
 
-	string SortedTimers::GetTimerDays(cTimer const& timer)
+	std::string SortedTimers::GetTimerDays(cTimer const& timer)
 	{
-		string currentDay = timer.WeekDays() > 0 ?
+		std::string currentDay = timer.WeekDays() > 0 ?
 			*cTimer::PrintDay(0, timer.WeekDays(), true) :
 			FormatDateTime(tr("%A, %x"), timer.Day());
 		return currentDay;
 	}
 
-	string SortedTimers::GetTimerInfo(cTimer const& timer)
+	std::string SortedTimers::GetTimerInfo(cTimer const& timer)
 	{
-		ostringstream info;
-		info << trVDR("Priority") << ": " << timer.Priority() << endl;
-		info << trVDR("Lifetime") << ": " << timer.Lifetime() << endl;
-		info << trVDR("VPS") << ": " << (timer.HasFlags(tfVps)?trVDR("yes"):trVDR("no")) << endl;
+		std::stringstream info;
+		info << trVDR("Priority") << ": " << timer.Priority() << std::endl;
+		info << trVDR("Lifetime") << ": " << timer.Lifetime() << std::endl;
+		info << trVDR("VPS") << ": " << (timer.HasFlags(tfVps)?trVDR("yes"):trVDR("no")) << std::endl;
 
 		if (timer.Aux())
 		{
-			string epgsearchinfo = GetXMLValue(timer.Aux(), "epgsearch");
+			std::string epgsearchinfo = GetXMLValue(timer.Aux(), "epgsearch");
 			if (!epgsearchinfo.empty())
 			{
-				string searchtimer = GetXMLValue(epgsearchinfo, "searchtimer");
+				std::string searchtimer = GetXMLValue(epgsearchinfo, "searchtimer");
 				if (!searchtimer.empty())
-					info << tr("Searchtimer") << ": " << searchtimer << endl;
+					info << tr("Searchtimer") << ": " << searchtimer << std::endl;
 			}
 		}
 #if VDRVERSNUM >= 20400
                 if (timer.Local()) {
-                  info << trVDR("Record on") << ": " << trVDR(" ") << endl;
+                  info << trVDR("Record on") << ": " << trVDR(" ") << std::endl;
                 } else {
-                  info << trVDR("Record on") << ": " << timer.Remote() << endl;
+                  info << trVDR("Record on") << ": " << timer.Remote() << std::endl;
                 }
 #endif
 		return info.str();
 	}
 
-	string SortedTimers::SearchTimerInfo(cTimer const& timer, std::string const& value)
+	std::string SortedTimers::SearchTimerInfo(cTimer const& timer, std::string const& value)
 	{
-		ostringstream info;
+		std::stringstream info;
 		if (timer.Aux())
 		{
-			string epgsearchinfo = GetXMLValue(timer.Aux(), "epgsearch");
+			std::string epgsearchinfo = GetXMLValue(timer.Aux(), "epgsearch");
 			if (!epgsearchinfo.empty())
 			{
-				string data = GetXMLValue(epgsearchinfo, value);
+				std::string data = GetXMLValue(epgsearchinfo, value);
 				if (!data.empty())
 					info << data;
 			}
@@ -188,12 +186,12 @@ namespace vdrlive {
 	{
 	}
 
-	void TimerManager::UpdateTimer( int timerId, const char* remote, const char* oldRemote, int flags, const tChannelID& channel, string const& weekdays,
-			                string const& day, int start, int stop, int priority, int lifetime, string const& title, string const& aux )
+	void TimerManager::UpdateTimer( int timerId, const char* remote, const char* oldRemote, int flags, const tChannelID& channel, std::string const& weekdays,
+			                std::string const& day, int start, int stop, int priority, int lifetime, std::string const& title, std::string const& aux )
 	{
 		cMutexLock lock( this );
 
-		ostringstream builder;
+		std::stringstream builder;
 		builder << flags << ":"
 				<< channel << ":"
 				<< ( weekdays != "-------" ? weekdays : "" )
@@ -226,7 +224,7 @@ namespace vdrlive {
 		m_updateWait.Wait( *this );
 		// dsyslog("live: SV: update done");
 
-		string error = GetError( timerData );
+		std::string error = GetError( timerData );
 		if ( !error.empty() )
 			throw HtmlError( error );
 	}
@@ -243,7 +241,7 @@ namespace vdrlive {
 		m_updateTimers.push_back( timerData );
 		m_updateWait.Wait( *this );
 
-		string error = GetError( timerData );
+		std::string error = GetError( timerData );
 		if ( !error.empty() )
 			throw HtmlError( error );
 	}
@@ -257,7 +255,7 @@ namespace vdrlive {
 		m_updateTimers.push_back( timerData );
 		m_updateWait.Wait( *this );
 
-		string error = GetError( timerData );
+		std::string error = GetError( timerData );
 		if ( !error.empty() )
 			throw HtmlError( error );
 	}
@@ -300,7 +298,7 @@ namespace vdrlive {
 		if ( timerData.remote ) {	// add remote timer via svdrpsend
 			dsyslog("live: DoInsertTimer() add remote timer on server '%s'", timerData.remote);
 			cStringList response;
-			string command = "NEWT ";
+			std::string command = "NEWT ";
 			command.append(timerData.builder);
 			dsyslog("live: DoInsertTimer() svdrp command '%s'", command.c_str());
 			bool svdrpOK = ExecSVDRPCommand(timerData.remote, command.c_str(), &response);
@@ -367,7 +365,7 @@ namespace vdrlive {
 			if ( timerData.remote == timerData.oldRemote ) {  // timer stays on the same remote server
 				dsyslog("live: DoUptimer() update timer on remote server '%s'", timerData.remote);
 				cStringList response;
-				string command = "MODT ";
+				std::string command = "MODT ";
 				command.append(std::to_string(timerData.id));
 				command.append(" ");
 				command.append(timerData.builder);
@@ -463,7 +461,7 @@ namespace vdrlive {
 		if ( timerData.remote ) {		// delete remote timer via svdrpsend
 			dsyslog("live: DoDeleteTimer() delete remote timer id '%d' from server '%s'", timerData.id, timerData.remote);
 			cStringList response;
-			string command = "DELT ";
+			std::string command = "DELT ";
 			command.append(std::to_string(timerData.id));
 			bool svdrpOK = ExecSVDRPCommand(timerData.remote, command.c_str(), &response);
 			if ( !svdrpOK ) {
@@ -531,7 +529,7 @@ namespace vdrlive {
 		if ( timerData.remote ) {		// toggle remote timer via svdrpsend
 			LOCK_TIMERS_READ;
 			const cTimer* toggleTimer = Timers->GetById( timerData.id, timerData.remote );
-			string command = "MODT ";
+			std::string command = "MODT ";
 			command.append(std::to_string(timerData.id));
 			if (toggleTimer->HasFlags(tfActive)) {
 				dsyslog("live: DoToggleTimer() timer is active");
@@ -600,14 +598,14 @@ namespace vdrlive {
 		m_failedUpdates.push_back( ErrorPair( timerData, error ) );
 	}
 
-	string TimerManager::GetError( timerStruct const& timerData )
+	std::string TimerManager::GetError( timerStruct const& timerData )
 	{
 		for ( ErrorList::iterator error = m_failedUpdates.begin(); error != m_failedUpdates.end(); ++error ) {
 			if ( error->first.id == timerData.id &&
 			     error->first.remote == timerData.remote &&
 			     error->first.oldRemote == timerData.oldRemote &&
 			     error->first.builder == timerData.builder ) {
-				string message = error->second;
+				std::string message = error->second;
 				m_failedUpdates.erase( error );
 				return message;
 			}

--- a/tntconfig.cpp
+++ b/tntconfig.cpp
@@ -14,8 +14,6 @@
 
 namespace vdrlive {
 
-	using namespace std;
-
 	TntConfig::TntConfig()
 	{
 	}
@@ -23,7 +21,7 @@ namespace vdrlive {
 	namespace {
 		std::string GetResourcePath()
 		{
-			string resourceDir(Plugin::GetResourceDirectory());
+			std::string resourceDir(Plugin::GetResourceDirectory());
 			return resourceDir;
 		}
 
@@ -45,7 +43,7 @@ namespace vdrlive {
 
 	void TntConfig::Configure(tnt::Tntnet& app) const
 	{
-		string const configDir(Plugin::GetConfigDirectory());
+		std::string const configDir(Plugin::GetConfigDirectory());
 
 #if TNT_LOG_SERINFO
 		cxxtools::SerializationInfo si;
@@ -140,7 +138,7 @@ namespace vdrlive {
 		// deprecated: file << "MapUrl ^/themes/([^/]*)/img.*/(.+)\\.(.+) $2@" << endl;
 
 		// Epg images
-		string const epgImgPath(LiveSetup().GetEpgImageDir());
+		std::string const epgImgPath(LiveSetup().GetEpgImageDir());
 		if (!epgImgPath.empty()) {
 			// inserted by 'tadi' -- verified with above, but not counterchecked yet!
 			MapUrl(app,
@@ -206,10 +204,10 @@ namespace vdrlive {
 
 #if TNT_GLOBAL_TNTCONFIG
 		tnt::TntConfig::it().sessionTimeout = 86400;
-		tnt::TntConfig::it().defaultContentType = string("text/html; charset=") + LiveI18n().CharacterEncoding();
+		tnt::TntConfig::it().defaultContentType = std::string("text/html; charset=") + LiveI18n().CharacterEncoding();
 #else
 		tnt::Sessionscope::setDefaultTimeout(86400);
-		tnt::HttpReply::setDefaultContentType(string("text/html; charset=") + LiveI18n().CharacterEncoding());
+		tnt::HttpReply::setDefaultContentType(std::string("text/html; charset=") + LiveI18n().CharacterEncoding());
 #endif
 
 		Setup::IpList const& ips = LiveSetup().GetServerIps();
@@ -220,7 +218,7 @@ namespace vdrlive {
 				esyslog("live: INFO: attempt to listen on ip = '%s'", ip->c_str());
 				app.listen(*ip, port);
 			}
-			catch (exception const & ex) {
+			catch (std::exception const & ex) {
 				esyslog("live: ERROR: ip = %s is invalid: exception = %s", ip->c_str(), ex.what());
 				if (++listenFailures == ips.size()) {
 					// if no listener was initialized we throw at
@@ -231,8 +229,8 @@ namespace vdrlive {
 		}
 
 		int s_port = LiveSetup().GetServerSslPort();
-		string s_cert = LiveSetup().GetServerSslCert();
-		string s_key = LiveSetup().GetServerSslKey();
+		std::string s_cert = LiveSetup().GetServerSslCert();
+		std::string s_key = LiveSetup().GetServerSslKey();
 
 		if (s_cert.empty()) {
 			s_cert = configDir + "/live.pem";
@@ -242,7 +240,7 @@ namespace vdrlive {
 			s_key = configDir + "/live-key.pem";
 		}
 
-		if ( ifstream( s_cert.c_str() ) && ifstream( s_key.c_str() ) ) {
+		if (std::ifstream( s_cert.c_str() ) && std::ifstream( s_key.c_str() ) ) {
 			for ( Setup::IpList::const_iterator ip = ips.begin(); ip != ips.end(); ++ip ) {
 				app.sslListen(s_cert, s_key, *ip, s_port);
 			}

--- a/tools.cpp
+++ b/tools.cpp
@@ -12,13 +12,12 @@
 #include <vdr/recording.h>
 #include <vdr/videodir.h>
 
-using namespace std;
 using namespace tnt;
 
-istream& operator>>( istream& is, tChannelID& ret )
+std::istream& operator>>( std::istream& is, tChannelID& ret )
 {
   /* alternativ implementation
-  string line;
+  std::string line;
   if ( !getline( is, line ) ) {
     if ( !is.eof() )
       is.setstate( ios::badbit );
@@ -31,31 +30,31 @@ istream& operator>>( istream& is, tChannelID& ret )
   return is;
   */
 
-  string line;
-  if (!getline( is, line ) ) {
+  std::string line;
+  if (!std::getline( is, line ) ) {
     if (0 == is.gcount()) {
-      is.clear(is.rdstate() & ~ios::failbit);
+      is.clear(is.rdstate() & ~std::ios::failbit);
       return is;
     }
     if (!is.eof()) {
-      is.setstate( ios::badbit );
+      is.setstate( std::ios::badbit );
       return is;
     }
   }
 
   if ( !line.empty() && !( ret = tChannelID::FromString( line.c_str() ) ).Valid() )
-    is.setstate( ios::badbit );
+    is.setstate( std::ios::badbit );
   return is;
 }
 
 namespace vdrlive {
 
-	string CorrectNonUTF8(string *str) // based on https://stackoverflow.com/questions/17316506/strip-invalid-utf8-from-string-in-c-c
+	std::string CorrectNonUTF8(std::string *str) // based on https://stackoverflow.com/questions/17316506/strip-invalid-utf8-from-string-in-c-c
 	{
 		int i, f_size = str->size();
 		unsigned char c, c3, c4;
 		unsigned char c2 = (unsigned char) 0;
-		string to;
+		std::string to;
 		to.reserve(f_size);
 
 		for(i = 0; i < f_size; i++) {
@@ -151,51 +150,51 @@ namespace vdrlive {
 		return to;
 	}
 
-	string FormatDuration( char const* format, int hours, int minutes )
+	std::string FormatDuration( char const* format, int hours, int minutes )
 	{
 		char result[ 32 ];
 		if ( snprintf(result, sizeof(result), format, hours, minutes) < 0 ) {
-			ostringstream builder;
+			std::stringstream builder;
 			builder << "cannot represent duration " << hours << ":" << minutes << " as requested";
-			throw runtime_error( builder.str() );
+			throw std::runtime_error( builder.str() );
 		}
 		return result;
 	}
 
-	string FormatDateTime( char const* format, time_t time )
+	std::string FormatDateTime( char const* format, time_t time )
 	{
 		struct tm tm_r;
 		if ( localtime_r( &time, &tm_r ) == 0 ) {
-			ostringstream builder;
+			std::stringstream builder;
 			builder << "cannot represent timestamp " << time << " as local time";
-			throw runtime_error( builder.str() );
+			throw std::runtime_error( builder.str() );
 		}
 
 		char result[ 256 ];
 		if ( strftime( result, sizeof( result ), format, &tm_r ) == 0 ) {
-			ostringstream builder;
+			std::stringstream builder;
 			builder << "representation of timestamp " << time << " exceeds " << sizeof( result ) << " bytes";
-			throw runtime_error( builder.str() );
+			throw std::runtime_error( builder.str() );
 		}
 		return result;
 	}
 
-	string StringReplace( string const& text, string const& substring, string const& replacement )
+	std::string StringReplace( std::string const& text, std::string const& substring, std::string const& replacement )
 	{
-		string result = text;
-		string::size_type pos = 0;
-		while ( ( pos = result.find( substring, pos ) ) != string::npos ) {
+		std::string result = text;
+		size_t pos = 0;
+		while ( ( pos = result.find( substring, pos ) ) != std::string::npos ) {
 			result.replace( pos, substring.length(), replacement );
 			pos += replacement.length();
 		}
 		return result;
 	}
 
-	vector< string > StringSplit( string const& text, char delimiter )
+	std::vector<std::string> StringSplit( std::string const& text, char delimiter )
 	{
-		vector< string > result;
-		string::size_type last = 0, pos;
-		while ( ( pos = text.find( delimiter, last ) ) != string::npos ) {
+		std::vector<std::string> result;
+		size_t last = 0, pos;
+		while ( ( pos = text.find( delimiter, last ) ) != std::string::npos ) {
 			result.push_back( text.substr( last, pos - last ) );
 			last = pos + 1;
 		}
@@ -213,16 +212,16 @@ namespace vdrlive {
 		return 0;
 	}
 
-	string StringRepeat(int times, const string& input)
+	std::string StringRepeat(int times, const std::string& input)
 	{
-		string result;
+		std::string result;
 		for (int i = 0; i < times; i++) {
 			result += input;
 		}
 		return result;
 	}
 
-	string StringWordTruncate(const string& input, size_t maxLen, bool& truncated)
+	std::string StringWordTruncate(const std::string& input, size_t maxLen, bool& truncated)
 	{
 		if (input.length() <= maxLen)
 		{
@@ -230,41 +229,41 @@ namespace vdrlive {
 			return input;
 		}
 		truncated = true;
-		string result = input.substr(0, maxLen);
+		std::string result = input.substr(0, maxLen);
 		size_t pos = result.find_last_of(" \t,;:.\n?!'\"/\\()[]{}*+-");
 		return result.substr(0, pos);
 	}
 
-	string StringFormatBreak(string const& input)
+	std::string StringFormatBreak(std::string const& input)
 	{
 		return StringReplace( input, "\n", "<br/>" );
 	}
 
-	string StringEscapeAndBreak( string const& input )
+	std::string StringEscapeAndBreak( std::string const& input )
 	{
-		stringstream plainBuilder;
+		std::stringstream plainBuilder;
 		HtmlEscOstream builder( plainBuilder );
 		builder << input;
 		return StringReplace( plainBuilder.str(), "\n", "<br/>" );
 	}
 
-	string StringTrim(string const& str)
+	std::string StringTrim(std::string const& str)
 	{
-		string res = str;
-		string::size_type pos = res.find_last_not_of(' ');
-		if(pos != string::npos) {
+		std::string res = str;
+		size_t pos = res.find_last_not_of(' ');
+		if(pos != std::string::npos) {
 			res.erase(pos + 1);
 			pos = res.find_first_not_of(' ');
-			if(pos != string::npos) res.erase(0, pos);
+			if(pos != std::string::npos) res.erase(0, pos);
 		}
 		else res.erase(res.begin(), res.end());
 		return res;
 	}
 
-	string ZeroPad(int number)
+	std::string ZeroPad(int number)
 	{
-		ostringstream os;
-		os << setw(2) << setfill('0') << number;
+		std::stringstream os;
+		os << std::setw(2) << std::setfill('0') << number;
 		return os.str();
 	}
 
@@ -273,14 +272,14 @@ namespace vdrlive {
 		char* szInput = strdup(str.c_str());
 		if (!szInput) return "";
 		char* szRes = MD5String(szInput);
-		string res = szRes;
+		std::string res = szRes;
 		free(szRes);
 		return res;
 
 /*	unsigned char md5[MD5_DIGEST_LENGTH];
 	MD5(reinterpret_cast<const unsigned char*>(str.c_str()), str.size(), md5);
 
-	ostringstream hashStr;
+	std::stringstream hashStr;
 	hashStr << hex;
 	for (size_t i = 0; i < MD5_DIGEST_LENGTH; i++)
 	hashStr << (0 + md5[i]);
@@ -294,24 +293,24 @@ namespace vdrlive {
 
 	std::string ExpandTimeString(std::string timestring)
 	{
-		string::size_type colonpos = timestring.find(":");
-		if (colonpos == string::npos)
+		size_t colonpos = timestring.find(":");
+		if (colonpos == std::string::npos)
 		{
 			if (timestring.size() == 1)
 				timestring = "0" + timestring + ":00";
 			else if (timestring.size() == 2)
 				timestring = timestring + ":00";
 			else if (timestring.size() == 3)
-				timestring = "0" + string(timestring.begin(), timestring.begin() + 1) + ":" + string(timestring.begin() + 1, timestring.end());
+				timestring = "0" + std::string(timestring.begin(), timestring.begin() + 1) + ":" + std::string(timestring.begin() + 1, timestring.end());
 			else
-				timestring = string(timestring.begin(), timestring.begin() + 2) + ":" + string(timestring.begin() + 2, timestring.end());
+				timestring = std::string(timestring.begin(), timestring.begin() + 2) + ":" + std::string(timestring.begin() + 2, timestring.end());
 		}
 		else
 		{
-			string hours = string(timestring.begin(), timestring.begin() + colonpos);
-			string mins = string(timestring.begin() + colonpos + 1, timestring.end());
-			hours = string(std::max(0,(int)(2 - hours.size())), '0') + hours;
-			mins = string(std::max(0,(int)(2 - mins.size())), '0') + mins;
+			std::string hours = std::string(timestring.begin(), timestring.begin() + colonpos);
+			std::string mins = std::string(timestring.begin() + colonpos + 1, timestring.end());
+			hours = std::string(std::max(0,(int)(2 - hours.size())), '0') + hours;
+			mins = std::string(std::max(0,(int)(2 - mins.size())), '0') + mins;
 			timestring = hours + ":" + mins;
 		}
 		return timestring;
@@ -331,9 +330,9 @@ namespace vdrlive {
 
 	struct urlencoder
 	{
-			ostream& ostr_;
+			std::ostream& ostr_;
 
-			explicit urlencoder( ostream& ostr ): ostr_( ostr ) {}
+			explicit urlencoder( std::ostream& ostr ): ostr_( ostr ) {}
 
 			void operator()( char ch )
 			{
@@ -353,28 +352,28 @@ namespace vdrlive {
 				if ( ch == ' ' )
 					ostr_ << '+';
 				else if ( static_cast< signed char >( ch ) < 0 || allowedChars[ size_t( ch ) ] == '_' )
-					ostr_ << '%' << setw( 2 ) << setfill( '0' ) << hex << int( static_cast< unsigned char >( ch ) );
+					ostr_ << '%' << std::setw( 2 ) << std::setfill( '0' ) << std::hex << int( static_cast< unsigned char >( ch ) );
 				else
 					ostr_ << ch;
 			}
 	};
 
-	string StringUrlEncode( string const& input )
+	std::string StringUrlEncode( std::string const& input )
 	{
-		ostringstream ostr;
+		std::stringstream ostr;
 		for_each( input.begin(), input.end(), urlencoder( ostr ) );
 		return ostr.str();
 	}
 
 // returns the content of <element>...</element>
-	string GetXMLValue( std::string const& xml, std::string const& element )
+	std::string GetXMLValue( std::string const& xml, std::string const& element )
 	{
-		string start = "<" + element + ">";
-		string end = "</" + element + ">";
-		string::size_type startPos = xml.find(start);
-		if (startPos == string::npos) return "";
-		string::size_type endPos = xml.find(end);
-		if (endPos == string::npos) return "";
+		std::string start = "<" + element + ">";
+		std::string end = "</" + element + ">";
+		size_t startPos = xml.find(start);
+		if (startPos == std::string::npos) return "";
+		size_t endPos = xml.find(end);
+		if (endPos == std::string::npos) return "";
 		return xml.substr(startPos + start.size(), endPos - startPos - start.size());
 	}
 
@@ -496,8 +495,8 @@ namespace vdrlive {
 					while ((e = d.Next()) != NULL) {
 						// skip generic entries
 						if (strcmp(e->d_name, ".") && strcmp(e->d_name, "..") && strcmp(e->d_name, "lost+found")) {
-							string sourceFile = source + e->d_name;
-							string targetFile = target + e->d_name;
+							std::string sourceFile = source + e->d_name;
+							std::string targetFile = target + e->d_name;
 
 							// copy only regular files
 							if (!stat(sourceFile.c_str(), &st1) && S_ISREG(st1.st_mode)) {

--- a/users.cpp
+++ b/users.cpp
@@ -13,8 +13,6 @@
 
 namespace vdrlive {
 
-using namespace std;
-
 std::string cUsers::logged_in_user;
 
 // -- cUser -----------------------------------------------------------------
@@ -26,7 +24,7 @@ cUser::cUser(int ID, const std::string& Name, const std::string& Password)
 
 void cUser::SetPassword(const std::string& Password)
 {
-	ostringstream passwordStr;
+	std::stringstream passwordStr;
 	passwordStr << Password.size() << "|" << MD5Hash(Password);
 	m_PasswordMD5 = passwordStr.str();
 }
@@ -34,14 +32,14 @@ void cUser::SetPassword(const std::string& Password)
 int cUser::GetPasswordLength() const
 {
 	// format is <length>:<md5-hash of password>
-	vector< string > parts = StringSplit( m_PasswordMD5, '|' );
+	std::vector<std::string> parts = StringSplit( m_PasswordMD5, '|' );
 	return (parts.size() > 0) ? lexical_cast< int >( parts[0] ) : 0;
 }
 
 std::string const cUser::GetMD5HashPassword() const
 {
 	// format is <length>:<md5-hash of password>
-	vector< string > parts = StringSplit( m_PasswordMD5, '|' );
+	std::vector<std::string> parts = StringSplit( m_PasswordMD5, '|' );
 	return (parts.size() > 1) ? parts[1] : "";
 }
 


### PR DESCRIPTION
Hi Markus,

this pull request removes any usage of _using namespace std;_ , renaming 'string' to 'std::string', 'ios' to 'std::ios'.

This is helpful to guarantee, that identifier used in VDR's core don't cause trouble with identifiers with same name in STL .
Also, 'string' vs 'std::string', 'vector' vs 'std::vector' was mixed across the whole plugin, which is sorted now.

Winfried