### PR TITLE
remove stdext and add DISABLE_TEMPLATES_COLLIDING_WITH_STL define to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,7 @@ SOINST = $(DESTDIR)$(LIBDIR)/$(SOFILE).$(APIVERSION)
 
 ### Includes and Defines (add further entries here):
 DEFINES	+= -D_GNU_SOURCE -DPLUGIN_NAME_I18N='"$(PLUGIN)"' -DTNTVERSION=$(TNTVERSION) -DCXXTOOLVER=$(CXXTOOLVER)
+DEFINES	+= -DDISABLE_TEMPLATES_COLLIDING_WITH_STL
 VERSIONSUFFIX = gen_version_suffix.h
 
 ### The object files (add further files here):

--- a/README
+++ b/README
@@ -47,9 +47,7 @@ Requirements:
 
 VDR >= 2.0.0
 
-gcc >= 3.1
-if gcc < 4.0:
-boost >= 1.32.0		- http://www.boost.org
+gcc >= 4.8.1
 PCRE >= 8.0.2     	- http://www.pcre.org/
 Tntnet >= 1.5.3		- http://www.tntnet.org/download.hms
 Cxxtools >= 1.4.3	- http://www.tntnet.org/download.hms

--- a/cache.h
+++ b/cache.h
@@ -22,7 +22,7 @@ class cache
 public:
 	typedef TKey key_type;
 	typedef TValue mapped_type;
-	typedef stdext::shared_ptr<mapped_type> ptr_type;
+	typedef std::shared_ptr<mapped_type> ptr_type;
 
 private:
 	typedef std::pair<key_type, ptr_type> value_type;

--- a/epg_events.h
+++ b/epg_events.h
@@ -20,7 +20,7 @@ namespace vdrlive
 
 	class EpgInfo;
 
-	typedef stdext::shared_ptr<EpgInfo> EpgInfoPtr;
+	typedef std::shared_ptr<EpgInfo> EpgInfoPtr;
 
 	// -------------------------------------------------------------------------
 

--- a/grab.h
+++ b/grab.h
@@ -7,7 +7,7 @@
 
 namespace vdrlive {
 
-typedef stdext::shared_ptr<char> GrabImagePtr;
+typedef std::shared_ptr<char> GrabImagePtr;
 typedef std::pair<GrabImagePtr, int> GrabImageInfo;
 
 class GrabImageTask;

--- a/pages/Makefile
+++ b/pages/Makefile
@@ -4,6 +4,8 @@ PLUGIN := live
 ### Additional options to silence TNTNET warnings
 TNTFLAGS ?= -Wno-overloaded-virtual -Wno-unused-variable
 
+DEFINES += -DDISABLE_TEMPLATES_COLLIDING_WITH_STL
+
 ### Includes and Defines (add further entries here):
 INCLUDES += -I$(VDRDIR)/include -I..
 

--- a/recman.cpp
+++ b/recman.cpp
@@ -19,10 +19,10 @@ namespace vdrlive {
 	/**
 	 *  Implementation of class RecordingsManager:
 	 */
-	stdext::weak_ptr<RecordingsManager> RecordingsManager::m_recMan;
-	stdext::shared_ptr<RecordingsTree> RecordingsManager::m_recTree;
-	stdext::shared_ptr<RecordingsList> RecordingsManager::m_recList;
-	stdext::shared_ptr<DirectoryList> RecordingsManager::m_recDirs;
+	std::weak_ptr<RecordingsManager> RecordingsManager::m_recMan;
+	std::shared_ptr<RecordingsTree> RecordingsManager::m_recTree;
+	std::shared_ptr<RecordingsList> RecordingsManager::m_recList;
+	std::shared_ptr<DirectoryList> RecordingsManager::m_recDirs;
 #if VDRVERSNUM >= 20301
 	cStateKey RecordingsManager::m_recordingsStateKey;
 #else
@@ -35,7 +35,7 @@ namespace vdrlive {
 	// use any longer, it will be freed automaticaly, which leads to a
 	// release of the VDR recordings lock. Upon requesting access to
 	// the RecordingsManager via LiveRecordingsManger function, first
-	// the weak ptr is locked (obtaining a stdext::shared_ptr from an possible
+	// the weak ptr is locked (obtaining a std::shared_ptr from an possible
 	// existing instance) and if not successfull a new instance is
 	// created, which again locks the VDR Recordings.
 	//
@@ -58,7 +58,7 @@ namespace vdrlive {
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (! recMan) {
-			return RecordingsTreePtr(recMan, stdext::shared_ptr<RecordingsTree>());
+			return RecordingsTreePtr(recMan, std::shared_ptr<RecordingsTree>());
 		}
 		return RecordingsTreePtr(recMan, m_recTree);
 	}
@@ -67,25 +67,25 @@ namespace vdrlive {
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (! recMan) {
-			return RecordingsListPtr(recMan, stdext::shared_ptr<RecordingsList>());
+			return RecordingsListPtr(recMan, std::shared_ptr<RecordingsList>());
 		}
-		return RecordingsListPtr(recMan, stdext::shared_ptr<RecordingsList>(new RecordingsList(m_recList, ascending)));
+		return RecordingsListPtr(recMan, std::shared_ptr<RecordingsList>(new RecordingsList(m_recList, ascending)));
 	}
 
 	RecordingsListPtr RecordingsManager::GetRecordingsList(time_t begin, time_t end, bool ascending) const
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (! recMan) {
-			return RecordingsListPtr(recMan, stdext::shared_ptr<RecordingsList>());
+			return RecordingsListPtr(recMan, std::shared_ptr<RecordingsList>());
 		}
-		return RecordingsListPtr(recMan, stdext::shared_ptr<RecordingsList>(new RecordingsList(m_recList, ascending)));
+		return RecordingsListPtr(recMan, std::shared_ptr<RecordingsList>(new RecordingsList(m_recList, ascending)));
 	}
 
 	DirectoryListPtr RecordingsManager::GetDirectoryList() const
 	{
 		RecordingsManagerPtr recMan = EnsureValidData();
 		if (!recMan) {
-			return DirectoryListPtr(recMan, stdext::shared_ptr<DirectoryList>());
+			return DirectoryListPtr(recMan, std::shared_ptr<DirectoryList>());
 		}
 		return DirectoryListPtr(recMan, m_recDirs);
 	}
@@ -275,7 +275,7 @@ namespace vdrlive {
 	RecordingsManagerPtr RecordingsManager::EnsureValidData()
 	{
 		// Get singleton instance of RecordingsManager.  'this' is not
-		// an instance of stdext::shared_ptr of the singleton
+		// an instance of std::shared_ptr of the singleton
 		// RecordingsManager, so we obtain it in the overall
 		// recommended way.
 		RecordingsManagerPtr recMan = LiveRecordingsManager();
@@ -299,21 +299,21 @@ namespace vdrlive {
 				m_recDirs.reset();
 			}
 			if (stateChanged || !m_recTree) {
-				m_recTree = stdext::shared_ptr<RecordingsTree>(new RecordingsTree(recMan));
+				m_recTree = std::shared_ptr<RecordingsTree>(new RecordingsTree(recMan));
 			}
 			if (!m_recTree) {
 				esyslog("live: creation of recordings tree failed!");
 				return RecordingsManagerPtr();
 			}
 			if (stateChanged || !m_recList) {
-				m_recList = stdext::shared_ptr<RecordingsList>(new RecordingsList(RecordingsTreePtr(recMan, m_recTree)));
+				m_recList = std::shared_ptr<RecordingsList>(new RecordingsList(RecordingsTreePtr(recMan, m_recTree)));
 			}
 			if (!m_recList) {
 				esyslog("live: creation of recordings list failed!");
 				return RecordingsManagerPtr();
 			}
 			if (stateChanged || !m_recDirs) {
-				m_recDirs = stdext::shared_ptr<DirectoryList>(new DirectoryList(recMan));
+				m_recDirs = std::shared_ptr<DirectoryList>(new DirectoryList(recMan));
 			}
 			if (!m_recDirs) {
 				esyslog("live: creation of directory list failed!");
@@ -666,13 +666,13 @@ namespace vdrlive {
 	 *  Implementation of class RecordingsTreePtr:
 	 */
 	RecordingsTreePtr::RecordingsTreePtr() :
-		stdext::shared_ptr<RecordingsTree>(),
+		std::shared_ptr<RecordingsTree>(),
 		m_recManPtr()
 	{
 	}
 
-	RecordingsTreePtr::RecordingsTreePtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr<RecordingsTree> recTree) :
-		stdext::shared_ptr<RecordingsTree>(recTree),
+	RecordingsTreePtr::RecordingsTreePtr(RecordingsManagerPtr recManPtr, std::shared_ptr<RecordingsTree> recTree) :
+		std::shared_ptr<RecordingsTree>(recTree),
 		m_recManPtr(recManPtr)
 	{
 	}
@@ -710,7 +710,7 @@ namespace vdrlive {
 		}
 	}
 
-	RecordingsList::RecordingsList(stdext::shared_ptr<RecordingsList> recList, bool ascending) :
+	RecordingsList::RecordingsList(std::shared_ptr<RecordingsList> recList, bool ascending) :
 		m_pRecVec(new RecVecType(recList->size()))
 	{
 		if (!m_pRecVec) {
@@ -724,7 +724,7 @@ namespace vdrlive {
 		}
 	}
 
-	RecordingsList::RecordingsList(stdext::shared_ptr<RecordingsList> recList, time_t begin, time_t end, bool ascending) :
+	RecordingsList::RecordingsList(std::shared_ptr<RecordingsList> recList, time_t begin, time_t end, bool ascending) :
 		m_pRecVec(new RecVecType())
 	{
 		if (end > begin) {
@@ -766,8 +766,8 @@ namespace vdrlive {
 	/**
 	 *  Implementation of class RecordingsList:
 	 */
-	RecordingsListPtr::RecordingsListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr<RecordingsList> recList) :
-		stdext::shared_ptr<RecordingsList>(recList),
+	RecordingsListPtr::RecordingsListPtr(RecordingsManagerPtr recManPtr, std::shared_ptr<RecordingsList> recList) :
+		std::shared_ptr<RecordingsList>(recList),
 		m_recManPtr(recManPtr)
 	{
 	}
@@ -836,8 +836,8 @@ namespace vdrlive {
 	/**
 	 *  Implementation of class DirectoryListPtr:
 	 */
-	DirectoryListPtr::DirectoryListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr<DirectoryList> recDirs) :
-		stdext::shared_ptr<DirectoryList>(recDirs),
+	DirectoryListPtr::DirectoryListPtr(RecordingsManagerPtr recManPtr, std::shared_ptr<DirectoryList> recDirs) :
+		std::shared_ptr<DirectoryList>(recDirs),
 		m_recManPtr(recManPtr)
 	{
 	}

--- a/recman.h
+++ b/recman.h
@@ -19,7 +19,7 @@ namespace vdrlive {
 
 	// Forward declations from epg_events.h
 	class EpgInfo;
-	typedef stdext::shared_ptr<EpgInfo> EpgInfoPtr;
+	typedef std::shared_ptr<EpgInfo> EpgInfoPtr;
 
 	/**
 	 *  Some forward declarations
@@ -33,9 +33,9 @@ namespace vdrlive {
 	class DirectoryListPtr;
 	class RecordingsItem;
 
-	typedef stdext::shared_ptr<RecordingsManager> RecordingsManagerPtr;
-	typedef stdext::shared_ptr<RecordingsItem> RecordingsItemPtr;
-	typedef stdext::weak_ptr<RecordingsItem> RecordingsItemWeakPtr;
+	typedef std::shared_ptr<RecordingsManager> RecordingsManagerPtr;
+	typedef std::shared_ptr<RecordingsItem> RecordingsItemPtr;
+	typedef std::weak_ptr<RecordingsItem> RecordingsItemWeakPtr;
 	typedef std::multimap<std::string, RecordingsItemPtr> RecordingsMap;
 
 
@@ -131,10 +131,10 @@ namespace vdrlive {
 #endif
 			static RecordingsManagerPtr EnsureValidData();
 
-			static stdext::weak_ptr<RecordingsManager> m_recMan;
-			static stdext::shared_ptr<RecordingsTree> m_recTree;
-			static stdext::shared_ptr<RecordingsList> m_recList;
-			static stdext::shared_ptr<DirectoryList> m_recDirs;
+			static std::weak_ptr<RecordingsManager> m_recMan;
+			static std::shared_ptr<RecordingsTree> m_recTree;
+			static std::shared_ptr<RecordingsList> m_recList;
+			static std::shared_ptr<DirectoryList> m_recDirs;
 #if VDRVERSNUM >= 20301
 			static cStateKey m_recordingsStateKey;
 #else
@@ -321,12 +321,12 @@ namespace vdrlive {
 	 *  A smart pointer to a recordings tree. As long as an instance of this
 	 *  exists the recordings are locked in the vdr.
 	 */
-	class RecordingsTreePtr : public stdext::shared_ptr<RecordingsTree>
+	class RecordingsTreePtr : public std::shared_ptr<RecordingsTree>
 	{
 		friend class RecordingsManager;
 
 		private:
-			RecordingsTreePtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr<RecordingsTree> recTree);
+			RecordingsTreePtr(RecordingsManagerPtr recManPtr, std::shared_ptr<RecordingsTree> recTree);
 
 		public:
 			RecordingsTreePtr();
@@ -350,8 +350,8 @@ namespace vdrlive {
 
 		private:
 			RecordingsList(RecordingsTreePtr recTree);
-			RecordingsList(stdext::shared_ptr<RecordingsList> recList, bool ascending);
-			RecordingsList(stdext::shared_ptr<RecordingsList> recList, time_t begin, time_t end, bool ascending);
+			RecordingsList(std::shared_ptr<RecordingsList> recList, bool ascending);
+			RecordingsList(std::shared_ptr<RecordingsList> recList, time_t begin, time_t end, bool ascending);
 
 		public:
 			typedef std::vector<RecordingsItemPtr> RecVecType;
@@ -397,12 +397,12 @@ namespace vdrlive {
 	 *  A smart pointer to a recordings list. As long as an instance of this
 	 *  exists the recordings are locked in the vdr.
 	 */
-	class RecordingsListPtr : public stdext::shared_ptr<RecordingsList>
+	class RecordingsListPtr : public std::shared_ptr<RecordingsList>
 	{
 		friend class RecordingsManager;
 
 		private:
-			RecordingsListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr<RecordingsList> recList);
+			RecordingsListPtr(RecordingsManagerPtr recManPtr, std::shared_ptr<RecordingsList> recList);
 
 		public:
 			virtual ~RecordingsListPtr();
@@ -441,12 +441,12 @@ namespace vdrlive {
 	 *  A smart pointer to a directory list. As long as an instance of this
 	 *  exists the recordings are locked in the vdr.
 	 */
-	class DirectoryListPtr : public stdext::shared_ptr<DirectoryList>
+	class DirectoryListPtr : public std::shared_ptr<DirectoryList>
 	{
 		friend class RecordingsManager;
 
 		private:
-			DirectoryListPtr(RecordingsManagerPtr recManPtr, stdext::shared_ptr<DirectoryList> recDirs);
+			DirectoryListPtr(RecordingsManagerPtr recManPtr, std::shared_ptr<DirectoryList> recDirs);
 
 		public:
 			virtual ~DirectoryListPtr();

--- a/stdext.h
+++ b/stdext.h
@@ -1,66 +1,8 @@
-#ifndef VDR_LIVE_STDEXT_H
-#define VDR_LIVE_STDEXT_H
+#pragma once
 
 #if __cplusplus >= 201103L
-
-#	include <functional>
-#	include <memory>
-
-namespace stdext = std;
-
-#elif __GNUC__ >= 4
-
-#	include <tr1/functional>
-#	include <tr1/memory>
-
-namespace stdext = std::tr1;
-
+   #include <functional>
+   #include <memory>
 #else
-
-#	include <boost/version.hpp>
-
-#	define BOOST_MAJOR_VERSION (BOOST_VERSION / 100000)
-#	define BOOST_MINOR_VERSION ((BOOST_VERSION / 100) % 1000)
-
-#	if BOOST_MAJOR_VERSION >= 1 && BOOST_MINOR_VERSION >= 34
-
-#		include <boost/tr1/functional.hpp>
-#		include <boost/tr1/memory.hpp>
-
-#	elif BOOST_MAJOR_VERSION >= 1 && BOOST_MINOR_VERSION >= 32
-
-#		include <boost/bind.hpp>
-#		include <boost/shared_ptr.hpp>
-#		include <boost/weak_ptr.hpp>
-
-namespace stdext {
-
-	using boost::bind;
-	using boost::shared_ptr;
-	using boost::weak_ptr;
-
-	namespace placeholders {
-		using ::_1;
-		using ::_2;
-		using ::_3;
-		using ::_4;
-		using ::_5;
-		using ::_6;
-		using ::_7;
-		using ::_8;
-		using ::_9;
-	}
-
-} // namespace stdext
-
-#	else
-
-#		error "Your Compiler is too old and you don't have boost >= 1.32.0 installed."
-#		error "Please either install boost 1.32.0 or higher (1.34.0 is recommended)"
-#		error "or upgrade your compiler suite to at least GCC 4.0"
-
-#	endif
-
+   #error "this plugin needs a compiler with C++11 support, ie. gcc-4.8.1 or higher"
 #endif
-
-#endif // VDR_LIVE_STDEXT_H

--- a/tasks.cpp
+++ b/tasks.cpp
@@ -16,10 +16,6 @@
 
 namespace vdrlive {
 
-using std::for_each;
-using stdext::bind;
-using namespace stdext::placeholders;
-
 const char* NowReplaying()
 {
 	return cReplayControl::NowReplaying();
@@ -244,6 +240,10 @@ void TaskManager::DoScheduledTasks()
 {
 	if ( m_taskQueue.empty() && m_stickyTasks.empty() )
 		return;
+
+   using std::for_each;
+   using std::bind;
+   using namespace std::placeholders;
 
 	cMutexLock lock( this );
 	for_each( m_taskQueue.begin(), m_taskQueue.end(), bind( &Task::Action, _1 ) );

--- a/timerconflict.h
+++ b/timerconflict.h
@@ -69,7 +69,7 @@ namespace vdrlive {
 	class TimerConflictNotifier
 	{
 		public:
-			typedef stdext::shared_ptr<TimerConflicts> TimerConflictsPtr;
+			typedef std::shared_ptr<TimerConflicts> TimerConflictsPtr;
 
 			TimerConflictNotifier();
 			virtual ~TimerConflictNotifier();


### PR DESCRIPTION
This request adds "DISABLE_TEMPLATES_COLLIDING_WITH_STL" to the Makefiles and removes namespace stdext.

'namespace stdext' was broken anyway - as it required gcc > 4, whereas 4.8.1. was minimum.
Anyway, nobody should use those old compilers for a fresh build.