### PR TITLE
clarify error message if cert/key can not be found

### DIFF
--- a/tntconfig.cpp
+++ b/tntconfig.cpp
@@ -246,7 +246,7 @@ namespace vdrlive {
 			}
 		}
 		else {
-			esyslog( "live: ERROR: Unable to load cert/key (%s/%s): %s", s_cert.c_str(), s_key.c_str(), strerror( errno ) );
+			esyslog( "live: ERROR: Unable to load cert/key (%s / %s): %s", s_cert.c_str(), s_key.c_str(), strerror( errno ) );
 		}
 	}
 


### PR DESCRIPTION
separate the two paths by spaces to avoid confusion

I'm carrying this patch since a long time in the openSUSE packages for the LIVE plugin.
I created it after being confused by the reported "file path" until I found that it's actually two paths concatenated :-)