### PR TITLE
preload.cpp: fix filename typo

### DIFF
--- a/preload.cpp
+++ b/preload.cpp
@@ -91,7 +91,7 @@ namespace vdrlive {
 			"img/tv.jpg",
 			"img/arrow_rec.gif",
 			"img/favicon.ico",
-			"img/playlist.pn",
+			"img/playlist.png",
 			"img/sd.png",
 			"img/hd.png",
 			"img/RecordingErrors.png",


### PR DESCRIPTION
On VDR startup, we receive the error message

`live: can't preload /usr/share/vdr/plugins/live/img/playlist.pn! Generated pages might be degraded!`

This patch fixes the filename img/playlist.pn -> img/playlist.png