### PR TITLE
Work around for audio detection of channels with broken component descriptor

### DIFF
--- a/recman.cpp
+++ b/recman.cpp
@@ -774,17 +774,17 @@ template void RecordingsItem::AppendShortTextOrDesc<cLargeString>(cLargeString &
 
         int RecordingsItemRec::SD_HD()
         {
-           if (m_video_SD_HD >= -1) return m_video_SD_HD; // < -1: not checked. -1: Radio. 0 is SD, 1 is HD, >1 is UHD or better
+           if (m_video_SD_HD >= -1) return m_video_SD_HD; // -2: not checked. -1: Radio. 0 is SD, 1 is HD, >1 is UHD or better
 // see ETSI EN 300 468, V1.15.1 (2016-03) or later, Chapter "6.2.8 Component Descriptor"
            const cComponents *components = RecInfo()->Components();
-//           bool videoStreamFound = false;
-//           bool audioStreamFound = false;
+           bool videoStreamFound = false;
+           bool audioStreamFound = false;
            if(components) for( int ix = 0; ix < components->NumComponents(); ix++) {
              tComponent * component = components->Component(ix);
              switch (component->stream) {
              case 1: // MPEG2
              case 5: // H.264
-//               videoStreamFound = true;
+               videoStreamFound = true;
                switch (component->type) {
                  case 1:
                  case 5: m_video_SD_HD = 0; break; // 4:3
@@ -809,7 +809,7 @@ template void RecordingsItem::AppendShortTextOrDesc<cLargeString>(cLargeString &
                // stream_content_ext == 0 -> video
                // stream_content_ext == 1 -> audio
                // we assume stream_content_ext == 0 (video). This might be wrong :( . On the other hand side, all this data might be wrong as broadcasters often ignore this standard
-//               videoStreamFound = true;
+               videoStreamFound = true;
                switch (component->type) {
                  case 0:  // stream_content_ext == 0 -> HD. stream_content_ext == 1 -> AC-4 main audio, mono
                  case 1:  // stream_content_ext == 0 -> HD. stream_content_ext == 1 -> AC-4 main audio, mono, dialogue enhancement enabled
@@ -825,18 +825,22 @@ template void RecordingsItem::AppendShortTextOrDesc<cLargeString>(cLargeString &
              case 4: // AC3 Audio
              case 6: // HE-AAC Audio
              case 7: // reserved for DTS audio modes
-//               audioStreamFound = true;
+               audioStreamFound = true;
                break;
              case 11:
-//               videoStreamFound = true; // guess as stream_content_ext is missing, assume stream_content_ext = 0xF
+               videoStreamFound = true; // guess as stream_content_ext is missing, assume stream_content_ext = 0xF
                break;
              }
            }
            if(m_video_SD_HD < -1)  // nothing known found
-             {
-//             if (!videoStreamFound && audioStreamFound) m_video_SD_HD = -1; // radio
-//             else // disable radio, as this is not reliable
-             m_video_SD_HD = 0; // no information -> SD as default
+           {
+             // Work around for channels with broken component descriptor, i.e. missing video component:
+             // Frame rate >= 24, very likely _has_ a video stream
+             videoStreamFound |= RecInfo()->FramesPerSecond() >= 24;
+             if (!videoStreamFound && audioStreamFound)
+               m_video_SD_HD = -1; // radio
+             else
+               m_video_SD_HD = 0; // no information -> SD as default
              if(RecInfo()->ChannelName() ) {
                size_t l = strlen(RecInfo()->ChannelName() );
                if( l > 3 && RecInfo()->ChannelName()[l-2] == 'H' && RecInfo()->ChannelName()[l-1] == 'D') m_video_SD_HD = 1;
@@ -904,7 +908,7 @@ void AppendScraperData(cLargeString &target, const std::string &s_IMDB_ID, const
 #endif
           target.append(", \"");
 // [11] HD_SD
-          target.append(SD_HD() == 0 ? 's': SD_HD() == 1 ? 'h': SD_HD() >= 2 ? 'u': 'r');
+          target.append("shur"[std::min(SD_HD(), 2) & 3]);
           target.append("\", \"");
 // [12] channel name
           AppendHtmlEscapedAndCorrectNonUTF8(target, RecInfo()->ChannelName() );

--- a/recman.h
+++ b/recman.h
@@ -241,7 +241,7 @@ template<class T>
       virtual const std::string ArchiveDescr() const { return "" ; }
       virtual const char *NewR() const { return "" ; }
       virtual const int RecordingErrors() const { return -1; }
-      virtual int SD_HD() { return m_video_SD_HD; } // < -1: not checked. -1: Radio. 0: SD. 1: HD. >1 UHD or better
+      virtual int SD_HD() { return m_video_SD_HD; } // -2: not checked. -1: Radio. 0: SD. 1: HD. >1 UHD or better
       virtual void AppendAsJSArray(cLargeString &target, bool displayFolder) { }
  		  bool recEntriesSorted() { return m_cmp_rec != NULL; }
  		  bool dirEntriesSorted() { return m_cmp_dir != NULL; }
@@ -272,7 +272,7 @@ template<class T>
       int m_s_episode_number = 0;
       int m_s_season_number = 0;
       int m_language = 0;
-      int m_video_SD_HD = -2;  // < -1: not checked. -1: Radio. 0 is SD, 1 is HD, >1 is UHD or better
+      int m_video_SD_HD = -2;  // -2: not checked. -1: Radio. 0 is SD, 1 is HD, >1 is UHD or better
 
       int m_duration_deviation = 0;
   };


### PR DESCRIPTION
The detection of radio channels in recordings page is currently deactivated because some transponders are missing the video component descriptor. This causes recordings of these channels to be detected as radio erroneously.

The work around fixes this issue by considering channels w/o video descriptor but a frame rate > 24 fps to be SDTV too.
Radio channels typically have significantly lower values in the order of 5 fps.