### PR TITLE
Feature: create new recording recording directory

### DIFF
--- a/live/css/styles.css
+++ b/live/css/styles.css
@@ -1251,13 +1251,8 @@ table.formular tr td {
 	border-bottom: 1px solid #C0C1DA;
 }
 
-table.formular tr td input {
-        margin-top: 5px;
-        margin-bottom: 2px;
-}
-
 table.formular tr td .dotted input {
-        margin-top: 0px;
+	margin-top: 0px;
 }
 
 table.formular tr td.leftcol {
@@ -1265,7 +1260,7 @@ table.formular tr td.leftcol {
 }
 
 table.formular tr td.rightcol {
-	padding-right: 7px;
+	padding: 2px;
 }
 
 table.formular tr td.label {
@@ -1276,7 +1271,6 @@ table.formular tr td.label {
 table.formular tr.head td {
 	color: white;
 	font-weight: bold;
-	margin: 0;
 	padding: 0;
 	border: none;
 }

--- a/pages/edit_recording.ecpp
+++ b/pages/edit_recording.ecpp
@@ -17,12 +17,13 @@ using namespace vdrlive;
 	// form parameters
 	std::string name = "";
 	std::string directory = "";
-        std::string delresume = "";
-        std::string delmarks = "";
-        std::string copy = "";
-        std::string sort;
-        std::string filter;
-        std::string flat;
+	std::string newdir = "";
+	std::string delresume = "";
+	std::string delmarks = "";
+	std::string copy = "";
+	std::string sort;
+	std::string filter;
+	std::string flat;
 </%args>
 <%session scope="global">
 bool logged_in(false);
@@ -54,11 +55,11 @@ const cRecording* recording;
 		if (name.empty())
 			message = tr("Please set a name for the recording!");
 		else if (recording) {
-			bool copy_only = false;
 			if (delresume == "delresume") LiveRecordingsManager()->DeleteResume(recording);
-		        if (delmarks == "delmarks") LiveRecordingsManager()->DeleteMarks(recording);
-		        if (copy == "copy") copy_only = true;
-			std::string filename =  directory.empty() ? name : StringReplace(directory, "/", "~") + "~" + name;
+			if (delmarks == "delmarks") LiveRecordingsManager()->DeleteMarks(recording);
+			bool copy_only = copy == "copy";
+			if (newdir != ".") directory = newdir;
+			std::string filename = directory.empty() ? name : StringReplace(directory, "/", "~") + "~" + name;
 			if (LiveRecordingsManager()->MoveRecording(recording, FileSystemExchangeChars(filename, true), copy_only))
 				return reply.redirect(!edit_rec_referer.empty() ? edit_rec_referer : "recordings.html");
 			else
@@ -95,6 +96,16 @@ const cRecording* recording;
 <%cpp>
 	}
 </%cpp>
+	<script type="text/javascript">
+		function new_dir() {
+			var dir = document.getElementById("directory");
+			dir.style.display = "none";
+			document.getElementById("new_dir_button").style.display = "none";
+			var newdir = document.getElementById("newdir");
+			newdir.value = dir.value;
+			newdir.style.display = "";
+		}
+	</script>
 	</head>
 	<body onload="adjustHeader()" onresize="adjustHeader()">
 <%cpp>
@@ -130,7 +141,7 @@ edit_rec_referer.append(flat);
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Directory") $>:</div></td>
 						<td class="rightcol">
-							<select name="directory" size="1" id="directory" style="margin-top: 5px">
+							<select name="directory" size="1" id="directory">
 <%cpp>
         RecordingsTreePtr recordingsTree(LiveRecordingsManager()->GetRecordingsTree());
 	for (const auto &dir: recordingsTree->getAllDirs() ) {
@@ -140,6 +151,8 @@ edit_rec_referer.append(flat);
 	}
 </%cpp>
 							</select>
+							<img id="new_dir_button" class="icon" src="<$ LiveSetup().GetThemedLink("img", "button_new.png") $>" title="<$tr("Create new directory")$>" onclick="new_dir()" style="vertical-align: middle">
+							<input type="text" name="newdir" id="newdir" value="." size="55" class="width99" style="display:none" />
 						</td>
 					</tr>
 					<tr>

--- a/pages/pageelems.ecpp
+++ b/pages/pageelems.ecpp
@@ -103,9 +103,10 @@ function addErrorIcon(s, numErrors, durationDeviation, duration, numTsFiles) {
 function addHdSdIcon(s, hdsd, toolTip) {
   s.a += '<div class=\"recording_sd_hd\"><img class=\"icon\" src=\"<$LiveSetup().GetThemedLinkPrefixImg()$>'
   s.a += hdsd
-  s.a += 'd.png\" width = \"25px\" title=\"'
-  s.a += toolTip
-  s.a += '\" /></div>'
+  s.a += 'd.png\" width = \"25px\"'
+  if (toolTip)
+    s.w += ' title=\"' + toolTip + '\"'
+  s.a += '/></div>'
 }
 
 function IMDBS(s, im_db, name) {

--- a/pages/recordings.ecpp
+++ b/pages/recordings.ecpp
@@ -215,7 +215,7 @@ function RecordingsSt(s, level, displayFolder, data) {
     s.a += obj[20]
     s.a += '</div></td><td>'
     addErrorIcon(s, obj[10], obj[17], obj[19], obj[21])
-    addHdSdIcon(s, obj[11], obj[12])
+    addHdSdIcon(s, obj[11])
     s.a += '</td>'  // end column with error / sd/hd image
     s.a += '<td><div class=\"recording_name'
     s.a += obj[13]

--- a/po/de_DE.po
+++ b/po/de_DE.po
@@ -191,6 +191,9 @@ msgstr "Name"
 msgid "Directory"
 msgstr "Verzeichnis"
 
+msgid "Create new directory"
+msgstr "Neues Verzeichnis erstellen"
+
 msgid "Delete resume information"
 msgstr "Wiedergabeposition löschen"
 

--- a/recman.cpp
+++ b/recman.cpp
@@ -97,6 +97,12 @@ namespace vdrlive {
 		if (!recording)
 			return false;
 
+		// Check for injections that try to escape from the video dir.
+		if (strcmp(name.c_str(), "../") == 0 || name.find("/..") != std::string::npos) {
+			esyslog("live: renaming failed: new name invalid \"%s\"", name.c_str());
+			return false;
+		}
+
 		std::string oldname = recording->FileName();
 		size_t found = oldname.find_last_of("/");
 
@@ -109,10 +115,8 @@ namespace vdrlive {
 		std::string newname = std::string(VideoDirectory) + "/" + name + oldname.substr(found);
 #endif
 
-		if (!MoveDirectory(oldname.c_str(), newname.c_str(), copy)) {
-			esyslog("live: renaming failed from '%s' to '%s'", oldname.c_str(), newname.c_str());
+		if (!MoveDirectory(oldname.c_str(), newname.c_str(), copy))
 			return false;
-		}
 
 #if VDRVERSNUM >= 20301
 		LOCK_RECORDINGS_WRITE;


### PR DESCRIPTION
When editing a recording it can only be moved to _existing_ directories. It is not possible to create a new sub directory.

This PR adds a button to enter a new target directory name. It replaces the drop down box by an input field.
The directory is created if it does not yet exist. The name must not contain `../`.