### PR TITLE
Feature: edit subtitle & description

### DIFF
--- a/live/css/styles.css
+++ b/live/css/styles.css
@@ -31,14 +31,14 @@ form {
 	padding: 0;
 }
 
-input {
+input, textarea {
 	border: 1px solid #6D96A9;
 	font-size: 11px;
 	font-family: Verdana, Arial, Helvetica, sans-serif;
 	background: #FEFEFE;
 	margin: 0;
 }
-input.width99 {
+input.width99, textarea.width99 {
 	width: 99%;
 }
 

--- a/pages/edit_recording.ecpp
+++ b/pages/edit_recording.ecpp
@@ -20,6 +20,8 @@ using namespace vdrlive;
 	std::string name = "";
 	std::string directory = "";
   std::string newdir = "";
+  std::string shorttext = "";
+  std::string description = "";
   std::string delresume = "";
   std::string delmarks = "";
   std::string copy = "";
@@ -64,7 +66,7 @@ const cRecording* recording;
       if (copy == "copy") copy_only = true;
       if (newdir != ".") directory = newdir;
 			std::string filename =  directory.empty() ? name : StringReplace(directory, "/", "~") + "~" + name;
-			if (LiveRecordingsManager()->MoveRecording(recording, FileSystemExchangeChars(filename, true), copy_only))
+			if (LiveRecordingsManager()->UpdateRecording(recording, FileSystemExchangeChars(filename, true), copy_only, shorttext, description))
         returnToReferer = true;
 			else
 				message = tr("Cannot copy, rename or move the recording.");
@@ -94,6 +96,9 @@ const cRecording* recording;
 			directory = "";
 			name = path;
 		}
+
+		shorttext = recording->Info()->ShortText();
+		description = recording->Info()->Description();
 	}
 </%cpp>
 <& pageelems.doc_type &>
@@ -140,7 +145,7 @@ const cRecording* recording;
 					</tr>
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Name") $>:</div></td>
-						<td class="rightcol"><input type="text" name="name" value="<$ name $>" size="55" class="width99" /></td>
+						<td class="rightcol"><input type="text" name="name" value="<$ name $>" size="100" class="width99" /></td>
 					</tr>
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Directory") $>:</div></td>
@@ -155,8 +160,8 @@ const cRecording* recording;
 	}
 </%cpp>
 							</select>
-              <img id="new_dir_button" class="icon" src="<$ LiveSetup().GetThemedLink("img", "button_new.png") $>" title="<$tr("Create new directory")$>" onclick="new_dir()" style="vertical-align: middle">
-							<input type="text" name="newdir" id="newdir" value="." size="55" class="width99" style="display:none" />
+							<img id="new_dir_button" class="icon" src="<$ LiveSetup().GetThemedLink("img", "button_new.png") $>" title="<$tr("Create new directory")$>" onclick="new_dir()" style="vertical-align: middle">
+							<input type="text" name="newdir" id="newdir" value="." size="100" class="width99" style="display:none" />
 						</td>
 					</tr>
 					<tr>
@@ -171,24 +176,16 @@ const cRecording* recording;
 						<td class="label leftcol"><div class="withmargin"><$ tr("Copy only") $>:</div></td>
 						<td class="rightcol"><input type="checkbox" name="copy" value="copy"/></td>
 					</tr>
-<%cpp>
-if (recording && recording->Info()->ShortText()) {
-</%cpp>
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Short description") $>:</div></td>
-						<td class="rightcol"><$ recording->Info()->ShortText() $></td>
+						<td class="rightcol"><input type="text" name="shorttext" value="<$ shorttext $>" size="55" class="width99" /></td>
 					</tr>
-<%cpp>
-}
-if (recording && recording->Info()->Description()) {
-</%cpp>
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Description") $>:</div></td>
-						<td class="rightcol"><$ recording->Info()->Description() $></td>
+						<td class="rightcol"><textarea name="description" rows="6" cols="100" class="width99"><$ description $></textarea></td>
 					</tr>
 <%cpp>
 
-}
 if (recording && recording->Info()->Aux()) {
   std::string aux_data;
   cGetAutoTimerReason getAutoTimerReason;

--- a/pages/edit_recording.ecpp
+++ b/pages/edit_recording.ecpp
@@ -1,6 +1,5 @@
 <%pre>
 
-#include <tools.h>
 #include <recman.h>
 #include <setup.h>
 #include <users.h>
@@ -65,8 +64,7 @@ const cRecording* recording;
       if (delmarks == "delmarks") LiveRecordingsManager()->DeleteMarks(recording);
       if (copy == "copy") copy_only = true;
       if (newdir != ".") directory = newdir;
-			std::string filename =  directory.empty() ? name : StringReplace(directory, "/", "~") + "~" + name;
-			if (LiveRecordingsManager()->UpdateRecording(recording, FileSystemExchangeChars(filename, true), copy_only, shorttext, description))
+			if (LiveRecordingsManager()->UpdateRecording(recording, directory, name, copy_only, shorttext, description))
         returnToReferer = true;
 			else
 				message = tr("Cannot copy, rename or move the recording.");
@@ -85,20 +83,16 @@ const cRecording* recording;
 	} else {
 
 	if (recording) {
-		std::string path = recording->Name();
-		size_t found = path.find_last_of("~");
-
-		if (found != std::string::npos) {
-			directory = StringReplace(path.substr(0, found), "~", "/");
-			name = path.substr(found + 1);
-		}
-		else {
-			directory = "";
-			name = path;
-		}
-
-		shorttext = recording->Info()->ShortText();
-		description = recording->Info()->Description();
+		cRecordingInfo *info = recording->Info();
+		cString basename = recording->BaseName(); 
+		name = cSv(info->Title());
+		if (name.empty())
+			name = basename;
+		if (basename[0] == '%')
+			name.insert(0, 1, '%');
+		directory = StringReplace(*recording->Folder(), "~", "/");
+		shorttext = cSv(info->ShortText());
+		description = cSv(info->Description());
 	}
 </%cpp>
 <& pageelems.doc_type &>
@@ -178,11 +172,11 @@ const cRecording* recording;
 					</tr>
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Short description") $>:</div></td>
-						<td class="rightcol"><input type="text" name="shorttext" value="<$ shorttext $>" size="55" class="width99" /></td>
+						<td class="rightcol"><input type="text" name="shorttext" value="<$ shorttext $>" size="100" class="width99" /></td>
 					</tr>
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Description") $>:</div></td>
-						<td class="rightcol"><textarea name="description" rows="6" cols="100" class="width99"><$ description $></textarea></td>
+						<td class="rightcol"><textarea name="description" rows="8" cols="100" class="width99"><$ description $></textarea></td>
 					</tr>
 <%cpp>
 

--- a/pages/edit_recording.ecpp
+++ b/pages/edit_recording.ecpp
@@ -19,6 +19,7 @@ using namespace vdrlive;
 	std::string name = "";
 	std::string directory = "";
   std::string newdir = "";
+  std::string title = "";
   std::string shorttext = "";
   std::string description = "";
   std::string delresume = "";
@@ -64,7 +65,7 @@ const cRecording* recording;
       if (delmarks == "delmarks") LiveRecordingsManager()->DeleteMarks(recording);
       if (copy == "copy") copy_only = true;
       if (newdir != ".") directory = newdir;
-			if (LiveRecordingsManager()->UpdateRecording(recording, directory, name, copy_only, shorttext, description))
+			if (LiveRecordingsManager()->UpdateRecording(recording, directory, name, copy_only, title, shorttext, description))
         returnToReferer = true;
 			else
 				message = tr("Cannot copy, rename or move the recording.");
@@ -84,13 +85,9 @@ const cRecording* recording;
 
 	if (recording) {
 		cRecordingInfo *info = recording->Info();
-		cString basename = recording->BaseName(); 
-		name = cSv(info->Title());
-		if (name.empty())
-			name = basename;
-		if (basename[0] == '%')
-			name.insert(0, 1, '%');
+		name = recording->BaseName(); 
 		directory = StringReplace(*recording->Folder(), "~", "/");
+		title = cSv(info->Title());
 		shorttext = cSv(info->ShortText());
 		description = cSv(info->Description());
 	}
@@ -169,6 +166,10 @@ const cRecording* recording;
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Copy only") $>:</div></td>
 						<td class="rightcol"><input type="checkbox" name="copy" value="copy"/></td>
+					</tr>
+					<tr>
+						<td class="label leftcol"><div class="withmargin"><$ tr("Title") $>:</div></td>
+						<td class="rightcol"><input type="text" name="title" value="<$ title $>" size="100" class="width99" /></td>
 					</tr>
 					<tr>
 						<td class="label leftcol"><div class="withmargin"><$ tr("Short description") $>:</div></td>

--- a/recman.cpp
+++ b/recman.cpp
@@ -102,7 +102,7 @@ template void StringAppendFrameParams<cToSvConcat<255>>(cToSvConcat<255> &s, con
 		return 0;
 	}
 
-	bool RecordingsManager::UpdateRecording(cRecording const * recording, cSv directory, cSv name, bool copy, cSv shorttext, cSv description) const
+	bool RecordingsManager::UpdateRecording(cRecording const * recording, cSv directory, cSv name, bool copy, cSv title, cSv shorttext, cSv description) const
 	{
 		if (!recording)
 			return false;
@@ -136,14 +136,13 @@ template void StringAppendFrameParams<cToSvConcat<255>>(cToSvConcat<255> &s, con
 
 		// update texts
 		// need null terminated strings for VDR API
-		std::string title(name, name.compare(0, 1, "%") == 0, std::string::npos);
 		std::string desc(description);
 		desc.erase(std::remove(desc.begin(), desc.end(), '\r'), desc.end()); // remove \r from HTML
 
 		cRecordingInfo* info = recording->Info();
 		if (title != cSv(info->Title()) || shorttext != cSv(info->ShortText()) || desc != cSv(info->Description()))
 		{
-			info->SetData(title.c_str(), shorttext.empty() ? nullptr : std::string(shorttext).c_str(), desc.empty() ? nullptr : desc.c_str());
+			info->SetData(title.empty() ? nullptr : std::string(title).c_str(), shorttext.empty() ? nullptr : std::string(shorttext).c_str(), desc.empty() ? nullptr : desc.c_str());
 			info->Write();
 		}
 

--- a/recman.h
+++ b/recman.h
@@ -79,12 +79,13 @@ template<typename T>
       /**
        *  Move a recording with the given hash according to
        *  VDRs recording mechanisms.
-       *  @param name new file name and title of the recording.
+       *  @param directory new name of the sub folder this recording is stored in.
+       *  @param name new title of the recording, will also synchronize the recording folder name.
        *  @param copy create a copy of the original recording rather than moving it.
        *  @param shorttext new short text of the recording.
        *  @param description new description of the recording.
        */
-      bool UpdateRecording(cRecording const * recording, cSv name, bool copy, const std::string& shorttext, const std::string description) const;
+      bool UpdateRecording(cRecording const * recording, cSv directory, cSv name, bool copy, cSv shorttext, cSv description) const;
 
       /**
        *  Delete recording resume with the given hash according to

--- a/recman.h
+++ b/recman.h
@@ -80,12 +80,13 @@ template<typename T>
        *  Move a recording with the given hash according to
        *  VDRs recording mechanisms.
        *  @param directory new name of the sub folder this recording is stored in.
-       *  @param name new title of the recording, will also synchronize the recording folder name.
+       *  @param name new recording folder name.
        *  @param copy create a copy of the original recording rather than moving it.
+       *  @param title new title of the recording.
        *  @param shorttext new short text of the recording.
        *  @param description new description of the recording.
        */
-      bool UpdateRecording(cRecording const * recording, cSv directory, cSv name, bool copy, cSv shorttext, cSv description) const;
+      bool UpdateRecording(cRecording const * recording, cSv directory, cSv name, bool copy, cSv title, cSv shorttext, cSv description) const;
 
       /**
        *  Delete recording resume with the given hash according to

--- a/recman.h
+++ b/recman.h
@@ -79,8 +79,12 @@ template<typename T>
       /**
        *  Move a recording with the given hash according to
        *  VDRs recording mechanisms.
+       *  @param name new file name and title of the recording.
+       *  @param copy create a copy of the original recording rather than moving it.
+       *  @param shorttext new short text of the recording.
+       *  @param description new description of the recording.
        */
-      bool MoveRecording(cRecording const * recording, cSv name, bool copy = false) const;
+      bool UpdateRecording(cRecording const * recording, cSv name, bool copy, const std::string& shorttext, const std::string description) const;
 
       /**
        *  Delete recording resume with the given hash according to


### PR DESCRIPTION
When editing a recording, not just the name should be changeable but also the subtitle and the description.
The change also ensures that the title in the VDR metadata is synchronized with the new name when renaming. This avoids displaying the old name in some clients and detail windows.