### PR TITLE
switch_channel.ecpp: extend with parameter (channel-)'number'

### DIFF
--- a/pages/switch_channel.ecpp
+++ b/pages/switch_channel.ecpp
@@ -9,11 +9,20 @@ using namespace vdrlive;
 
 </%pre>
 <%args>
+  int number; // should be optional!
   std::string param;
   std::string async;
 </%args>
 <%cpp>
-  tChannelID paramID = tChannelID::FromString(param.c_str());
+  tChannel channelID;
+  if (qparam.has("number")) {
+    LOCK_CHANNELS_READ;
+    const cChannel* channel = Channels->GetByNumber(number);
+    channelID = channel ? channel->GetChannelID() : tChannelID::InvalidID;
+  }
+  else {
+    channelID = tChannelID::FromString(param.c_str());
+  }
   bool ajaxReq = !async.empty() && (parse_int<int>(async) != 0);
   std::string referrer;
 
@@ -27,7 +36,7 @@ using namespace vdrlive;
     referrer = request.getHeader("Referer:");
   }
 
-  SwitchChannelTask task( paramID );
+  SwitchChannelTask task( channelID );
   LiveTaskManager().Execute( task );
 
   if (!ajaxReq) {
@@ -44,7 +53,7 @@ Seitenende!
   }
   else {
 </%cpp>
-<& xmlresponse.ajax name=("switch_channel") pname=("channel") value=(paramID) result=(task.Result()) error=(task.Error()) &>
+<& xmlresponse.ajax name=("switch_channel") pname=("channel") value=(channelID) result=(task.Result()) error=(task.Error()) &>
 <%cpp>
   }
 </%cpp>


### PR DESCRIPTION
Hallo Markus!

Könntest du dir bitte den (komplett ungetesteten!) Vorschlag anschauen und ggf. anpassen und dann übernehmen?

Ziel ist, dass via URL-Aufruf von irgendwo im LAN am VDR der Kanal auf die mitgegebene Nummer umgeschaltet wird.
zB http://192.168.x.y:8008/vdr_request/switch_channel?number=10
(statt wie bisher über die ID: http://192.168.x.y:8008/vdr_request/switch_channel?param=S19.2E-1-1019-10301)

Der zugehörige Thread im vdr-portal ist [hier](https://www.vdr-portal.de/forum/index.php?thread/136498-kanal-umschalten-per-url-bzw-sprachassistent/&postID=1375510#post1375510).

btw:
Entweder funktioniert beim Setup "Lokales Netz (keine Anmeldung notwendig):" nicht korrekt, oder meine Eingabe "192.168.x.0/24" ist falsch.

Danke u lg
  davie2000
  
PS: im Nachhinein wäre ich gerne weniger invasiv vorgegangen und hätte deine "paramID" einfach weiterverwendet, aber ich fand keine Möglichkeit, das zu ändern, weil ich wahrscheinlich zu früh auf "pull request" geklickt habe - SORRY!