### PR TITLE
Hide empty directories in recordings on search

### DIFF
--- a/pages/recordings.ecpp
+++ b/pages/recordings.ecpp
@@ -303,6 +303,7 @@ if (currentFlat != "true") {
 // each subdir has an identifier in <ul> tag: fldr_<$ idHash $>
       RecordingsItemDirPtr recItem = *dirIter;
 
+      if (!recItem->matchesFilter(currentFilter)) continue;
       /* search trough directory for new recordings */
       bool newR = false;
       if ( LiveSetup().GetMarkNewRec() ) newR = recItem->checkNew();

--- a/recman.cpp
+++ b/recman.cpp
@@ -579,6 +579,13 @@ bool searchNameDesc(RecordingsItemRecPtr &RecItem, const std::vector<RecordingsI
     return m_s_image;
   }
 
+  bool RecordingsItemDir::matchesFilter(cSv filter) const {
+    if (filter.empty()) return true;
+    for (const auto &rec:m_entries) if (rec->matchesFilter(filter)) return true;
+    for (const auto &subdir:m_subdirs) if (subdir->matchesFilter(filter)) return true;
+    return false;
+  }
+
   /**
    *  Implementation of class RecordingsItemDirCollection:
    */

--- a/recman.h
+++ b/recman.h
@@ -235,6 +235,9 @@ cToSvConcat<N> & StringAppendFrameParams(cToSvConcat<N> &s, const cRecording *re
        bool recEntriesSorted() const { return m_cmp_rec != NULL; }
        bool dirEntriesSorted() const { return m_cmp_dir != NULL; }
 
+      // To display the recording on the UI
+      bool matchesFilter(cSv filter) const;
+
     protected:
       std::string m_name;
       int m_level;


### PR DESCRIPTION
When searching for a text in the recordings view (not flat) all directory items are shown regardless whether they contain a match or not. It is quite difficult to find the matches by expanding all directories.

Directories that do not contain any match should not be shown.

This patch adds a recursive check similar to the check for new recordings.