### PR TITLE
fixes compiler warning: variable 'i' set but not used

### DIFF
--- a/pages/edit_searchtimer.ecpp
+++ b/pages/edit_searchtimer.ecpp
@@ -833,7 +833,7 @@ const char *TNT_ARRAY = "";
                 <div id="channelgroup" style="display: none">
 %               if (channelGroups.size() > 0) {
                   <select name="changrpsel" size="1" id="changrpsel">
-%                 int i = 0; for (ChannelGroups::iterator changrp = channelGroups.begin(); changrp != channelGroups.end(); ++changrp, i++) {
+%                 ; for (ChannelGroups::iterator changrp = channelGroups.begin(); changrp != channelGroups.end(); ++changrp) {
                     <option value="<$ changrp->Name() $>" <{ SELECTIF(changrpsel == changrp->Name()) }> ><$ changrp->Name() $></option>
 %                 }
                   </select>

--- a/pages/searchepg.ecpp
+++ b/pages/searchepg.ecpp
@@ -543,7 +543,7 @@ const char *TNT_ARRAY = "";
                 <div id="channelgroup" style="display: none">
 %               if (channelGroups.size() > 0) {
                   <select name="changrpsel" size="1" id="changrpsel">
-%                 int i = 0; for (ChannelGroups::iterator changrp = channelGroups.begin(); changrp != channelGroups.end(); ++changrp, i++) {
+%                 ; for (ChannelGroups::iterator changrp = channelGroups.begin(); changrp != channelGroups.end(); ++changrp) {
                     <option value="<$ changrp->Name() $>" <{ SELECTIF(changrpsel == changrp->Name()) }> ><$ changrp->Name() $></option>
 %                 }
                   </select>

--- a/pages/whats_on.ecpp
+++ b/pages/whats_on.ecpp
@@ -354,7 +354,7 @@ if (type == "now") {
   std::string string_times = LiveSetup().GetTimes();
   cSplit parts(string_times, ';');
   auto part = parts.begin();
-  for (int i = 0; part != parts.end(); ++i, ++part) {
+  for (; part != parts.end(); ++part) {
 </%cpp>
   <option <%cpp> reply.out() << ( (current_fixtime != "" && *part == current_displaytime) ? "selected=\"selected\"" : "" ); </%cpp>value="<$ *part $>"> <$ cToSvConcat(tr("at"), ' ', *part) $></option>
 <%cpp>

--- a/timerconflict.cpp
+++ b/timerconflict.cpp
@@ -41,7 +41,7 @@ namespace vdrlive {
     if (parts.size() > 0) {
       conflictTime = parse_int<time_t>(*part);
       ++part;
-      for ( int i = 1; part != parts.end(); ++i, ++part ) {
+      for ( ; part != parts.end(); ++part ) {
         cSplit timerparts( *part, '|' );
         auto timerpart = timerparts.begin();
         TimerInConflict timer;
@@ -52,7 +52,7 @@ namespace vdrlive {
             case 2: {
               cSplit conctimerparts( *timerpart, '#' );
               auto conctimerpart = conctimerparts.begin();
-              for ( int k = 0; conctimerpart != conctimerparts.end(); ++k, ++conctimerpart )
+              for ( ; conctimerpart != conctimerparts.end(); ++conctimerpart )
                 timer.concurrentTimerIndices.push_back(parse_int<int>( *conctimerpart ));
               break;
             }


### PR DESCRIPTION
```c++
whats_on.ecpp: In member function 'virtual unsigned int {anonymous}::_component_::whats_on_actions_type::operator()(tnt::HttpRequest&, tnt::HttpReply&, tnt::QueryParams&)': whats_on.ecpp:357:12: warning: variable 'i' set but not used [-Wunused-but-set-variable=]
  357 |   for (int i = 0; part != parts.end(); ++i, ++part) {
      |            ^

edit_searchtimer.ecpp: In member function 'virtual unsigned int {anonymous}::_component_::operator()(tnt::HttpRequest&, tnt::HttpReply&, tnt::QueryParams&)': edit_searchtimer.ecpp:836:22: warning: variable 'i' set but not used [-Wunused-but-set-variable=]
  836 | %                 int i = 0; for (ChannelGroups::iterator changrp = channelGroups.begin(); changrp != channelGroups.end(); ++changrp, i++) {
      |                      ^

searchepg.ecpp: In member function 'virtual unsigned int {anonymous}::_component_::operator()(tnt::HttpRequest&, tnt::HttpReply&, tnt::QueryParams&)': searchepg.ecpp:546:22: warning: variable 'i' set but not used [-Wunused-but-set-variable=]
  546 | %                 int i = 0; for (ChannelGroups::iterator changrp = channelGroups.begin(); changrp != channelGroups.end(); ++changrp, i++) {
      |                      ^

timerconflict.cpp: In constructor 'vdrlive::TimerConflict::TimerConflict(const std::string&)': timerconflict.cpp:55:25: warning: variable 'k' set but not used [-Wunused-but-set-variable=]
   55 |               for ( int k = 0; conctimerpart != conctimerparts.end(); ++k, ++conctimerpart )
      |                         ^
timerconflict.cpp:44:17: warning: variable 'i' set but not used [-Wunused-but-set-variable=]
   44 |       for ( int i = 1; part != parts.end(); ++i, ++part ) {
      |                 ^
``` 