### PR TITLE
Deliver reduced images for thumbnails in recordings and schedule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ endif
 
 CXXTOOLVER := $(shell cxxtools-config --version | sed -e's/\.//g' | sed -e's/pre.*//g' | awk '/^..$$/ { print $$1."000"} /^...$$/ { print $$1."00"} /^....$$/ { print $$1."0" } /^.....$$/ { print $$1 }')
 
+# For rough image scaling, used by VDR core anyway
+LIBS += -ljpeg
 
 ### Optional configuration features
 PLUGINFEATURES :=
@@ -107,7 +109,7 @@ DEFINES	+= -DVERSION_SUFFIX='"$(VERSION_SUFFIX)"'
 PLUGINOBJS := $(PLUGIN).o recman.o epg_events.o thread.o tntconfig.o setup.o \
               timers.o tools.o status.o epgsearch.o \
               md5.o livefeatures.o timerconflict.o \
-              users.o osd_status.o ffmpeg.o xxhash.o
+              users.o osd_status.o ffmpeg.o xxhash.o content.o
 PLUGINSRCS := $(patsubst %.o,%.cpp,$(PLUGINOBJS))
 
 WEB_LIB_PAGES := libpages.a

--- a/content.cpp
+++ b/content.cpp
@@ -1,0 +1,180 @@
+#include "content.h"
+#include <istream>
+#include <memory>
+#include <jpeglib.h>
+
+#define JPEG_QUALITY 85
+#define JPEG_BUFFER_SIZE 65536
+
+namespace vdrlive {
+
+namespace {
+
+struct error_mgr : public jpeg_error_mgr
+{ error_mgr()
+  { jpeg_std_error(this);
+    error_exit = [](j_common_ptr cinfo) { throw cinfo->err; };
+  }
+};
+
+class cpp_source_mgr : public jpeg_source_mgr
+{
+  std::ifstream& in;
+  const std::unique_ptr<JOCTET[]> buffer;
+
+  void InitSource()
+  { in.rdbuf()->pubsetbuf(nullptr, 0); // avoid double buffering
+    in.seekg(0);
+  }
+  boolean FillInputBuffer()
+  { in.read((char*)buffer.get(), JPEG_BUFFER_SIZE);
+    bytes_in_buffer = in.gcount();
+    if (!bytes_in_buffer)
+      return FALSE;
+    next_input_byte = buffer.get();
+    return TRUE;
+  }
+  void SkipInputData(long num)
+  { if (num <= 0)
+      return;
+    if ((unsigned long)num <= bytes_in_buffer)
+    { next_input_byte += num;
+      bytes_in_buffer -= num;
+    }
+    else
+    { in.seekg(num - bytes_in_buffer, in.cur);
+      FillInputBuffer();
+    }
+  }
+
+public:
+  cpp_source_mgr(std::ifstream& in)
+  : in(in),
+    buffer(new JOCTET[JPEG_BUFFER_SIZE])
+  {
+    bytes_in_buffer = 0;
+    init_source = [](j_decompress_ptr cinfo) { ((cpp_source_mgr*)cinfo->src)->InitSource(); };
+    fill_input_buffer = [](j_decompress_ptr cinfo) { return ((cpp_source_mgr*)cinfo->src)->FillInputBuffer(); };
+    skip_input_data = [](j_decompress_ptr cinfo, long num) { ((cpp_source_mgr*)cinfo->src)->SkipInputData(num); };
+    resync_to_restart = jpeg_resync_to_restart;
+    term_source = [](j_decompress_ptr cinfo) {};
+  }
+};
+
+class decompress : public jpeg_decompress_struct
+{
+  error_mgr Err;
+  cpp_source_mgr Src;
+  decompress(const decompress&) = delete;
+  void operator=(const decompress&) = delete;
+public:
+  decompress(std::ifstream& in)
+  : Src(in)
+  { jpeg_create_decompress(this);
+    err = &Err;
+    src = &Src;
+  }
+  ~decompress()
+  { jpeg_destroy_decompress(this);
+  }
+};
+
+class cpp_destination_mgr : public jpeg_destination_mgr
+{
+  void Enlarge()
+  { size_t s = data.size();
+    data.resize(s + JPEG_BUFFER_SIZE);
+    next_output_byte = (JOCTET*)data.data() + s;
+    free_in_buffer = JPEG_BUFFER_SIZE;
+  }
+  void Truncate()
+  { data.resize(data.size() - free_in_buffer);
+  }
+public:
+  std::string data;
+  cpp_destination_mgr()
+  { free_in_buffer = 0;
+    init_destination = [](j_compress_ptr cinfo) { ((cpp_destination_mgr*)cinfo->dest)->Enlarge(); };
+    empty_output_buffer = [](j_compress_ptr cinfo) { ((cpp_destination_mgr*)cinfo->dest)->Enlarge(); return TRUE; };
+    term_destination = [](j_compress_ptr cinfo) { ((cpp_destination_mgr*)cinfo->dest)->Truncate(); };
+  }
+};
+
+class compress : public jpeg_compress_struct
+{
+  error_mgr Err;
+  cpp_destination_mgr Dest;
+public:
+  compress()
+  { jpeg_create_compress(this);
+    err = &Err;
+    dest = &Dest;
+  }
+  ~compress()
+  { jpeg_destroy_compress(this);
+  }
+  std::string& Data() { return Dest.data; }
+};
+
+} // namespace
+
+std::size_t cFileContent::ReduceImageSize(unsigned width, unsigned height)
+{
+  struct decompress src(file);
+
+  try
+  {
+    jpeg_read_header(&src, TRUE);
+
+    // calculate decimation factor
+    int df = 0;
+    do
+    { width <<= 1;
+      height <<= 1;
+    } while ((src.image_width >= width || src.image_height >= height) && ++df != 3);
+    if (df == 0) // no scaling required
+      goto nope;
+
+    src.scale_num = 1;
+    src.scale_denom = 1 << df;
+
+    // init decompress
+    src.data_precision = 8; // no HDR in preview
+    jpeg_start_decompress(&src);
+
+    // allocate scanline buffer
+    unsigned row_stride = src.output_width * src.output_components;
+    JSAMPARRAY buffer = (*src.mem->alloc_sarray)((j_common_ptr)&src, JPOOL_IMAGE, row_stride, src.rec_outbuf_height);
+
+    // init compress
+    compress dst;
+    dst.image_width = src.output_width;
+    dst.image_height = src.output_height;
+    dst.input_components = src.output_components;
+    dst.in_color_space = src.out_color_space;
+    dst.data_precision = 8;
+    jpeg_set_defaults(&dst);
+    jpeg_set_quality(&dst, JPEG_QUALITY, TRUE);
+    jpeg_start_compress(&dst, TRUE);
+
+    // transfer data
+    while (src.output_scanline < src.output_height)
+    { unsigned lines = jpeg_read_scanlines(&src, buffer, src.rec_outbuf_height);
+      jpeg_write_scanlines(&dst, buffer, lines);
+    }
+
+    jpeg_finish_compress(&dst);
+    jpeg_finish_decompress(&src);
+
+    // capture result
+    reduced = std::move(dst.Data());
+    return reduced.size();
+  }
+  catch (jpeg_error_mgr*) {} // from error_mgr.error_exit
+
+nope:
+  file.seekg(0);
+  return 0; // keep original file content
+}
+
+}

--- a/content.h
+++ b/content.h
@@ -1,0 +1,34 @@
+#ifndef VDR_LIVE_CONTENT_H_
+#define VDR_LIVE_CONTENT_H_
+
+#include <fstream>
+
+namespace vdrlive {
+
+/// File content class
+/// @details May represent a reduced image or just a file.
+class cFileContent
+{
+  std::ifstream file;
+  std::string reduced;
+
+public:
+  cFileContent(const std::string& path) : file(path, std::ifstream::binary) {}
+  /// Check whether the source stream is valid.
+  explicit operator bool() const { return !!file; }
+  /// Scale an image file for a minimum target size.
+  /// @return Size of the reduced data in bytes.
+  /// 0 if failed. In this case the original file content is returned.
+  /// @remarks The scaling uses DCT decimation only and will likely return a larger image.
+  std::size_t ReduceImageSize(unsigned width, unsigned height);
+  /// Write the (reduced) content to a stream.
+  void WriteTo(std::ostream& out)
+  { if (reduced.empty())
+      out << file.rdbuf();
+    else
+      out << reduced;
+  }
+};
+
+}
+#endif // VDR_LIVE_CONTENT_H_

--- a/live/js/live/createHtml.js
+++ b/live/js/live/createHtml.js
@@ -68,7 +68,7 @@ function addScraperImageTitle(s, image, pt, title, seasonEpisode, runtime, date)
   if (image.length != 0) {
     s.a += '/tvscraper/'
     s.a += image
-    s.a += '\" class=\"thumb'
+    s.a += '?size=120\" class=\"thumb'
     s.a += pt
   } else s.a += 'img/transparent.png\" style=\"height: var(--icon-height, 16px)'
   if (title.length != 0 || date.length != 0) {

--- a/pages/content.ecpp
+++ b/pages/content.ecpp
@@ -6,6 +6,7 @@
 #include <tntfeatures.h>
 #include <vdr/channels.h>
 #include <stringhelpers.h>
+#include "content.h"
 
 using namespace vdrlive;
 
@@ -13,6 +14,9 @@ using namespace vdrlive;
 <%session scope="global">
 bool logged_in(false);
 </%session>
+<%args>
+size;
+</%args>
 <%cpp>
 std::string mime;
 if (request.getArgsCount() > 0) {
@@ -21,6 +25,10 @@ if (request.getArgsCount() > 0) {
 #else
   mime = request.getArg(0);
 #endif
+if (mime == "image/jpg")
+  mime = "image/jpeg";
+else if (mime == "image/svg")
+  mime = "image/svg+xml";
 //  dsyslog("vdrlive::content found mime arg (%s)", mime.c_str());
 } else  {
 mime = "image/png";
@@ -48,6 +56,9 @@ struct stat st;
 if (stat(path.c_str(), &st) != 0) {
   return DECLINED;
 }
+
+reply.setHeader(tnt::httpheader::cacheControl, "public, max-age=2592000"); // cache for 30 days, even when URL has parameters
+
 // file exists, length st.st_size, modification time st.st_mtime
 std::string mtime = tnt::HttpMessage::htdate(st.st_mtime);
 std::string browserTime = request.getHeader(tnt::httpheader::ifModifiedSince);
@@ -57,11 +68,20 @@ if (browserTime == mtime) {
 }
 // dsyslog("vdrlive::content: mimetype(%s), path = %s, modified", mime.c_str(), path.c_str());
 
+cFileContent data(path);
 
-std::ifstream in(path, std::ifstream::binary);
-if (!in) {
+if (!data) {
   esyslog("vdrlive::content: mimetype(%s), path = %s, found by fstat, but in == 0", mime.c_str(), path.c_str());
   return DECLINED;
+}
+
+if (!size.empty() && mime == "image/jpeg") {
+  size_t s = (size_t)stoul(size);
+  if (s > 0) {
+    s = data.ReduceImageSize(s, s);
+    if (s > 0)
+      st.st_size = s;
+  }
 }
 
 reply.setContentType(mime);
@@ -69,24 +89,7 @@ reply.setContentLengthHeader(st.st_size);
 reply.setHeader(tnt::httpheader::lastModified, mtime);
 
 reply.setDirectMode();
-reply.out() << in.rdbuf();
 
-/*
-FileCache::ptr_type f = LiveFileCache().get(path);
+data.WriteTo(reply.out());
 
-if (f.get() == 0) {
-  // dsyslog("vdrlive::content: DECLINED");
-  return DECLINED;
-}
-std::string ctime = tnt::HttpMessage::htdate(f->ctime());
-std::string browserTime = request.getHeader(tnt::httpheader::ifModifiedSince);
-if (browserTime == ctime) {
-  // dsyslog("vdrlive::content: HTTP_NOT_MODIFIED");
-  return HTTP_NOT_MODIFIED;
-}
-
-// dsyslog("vdrlive::content: send %d bytes of data", f->size());
-reply.setHeader(tnt::httpheader::lastModified, ctime);
-reply.out().write(f->data(), f->size());
-*/
 </%cpp>

--- a/pages/recordings.ecpp
+++ b/pages/recordings.ecpp
@@ -395,7 +395,7 @@ for (const RecordingsItemDirPtr &recItem: l_dir_iterator) {
 %     if (!recItem->scraperImage().path.empty() ) {
         <td class = space>
           <div class="thumb">
-            <img data-src="/tvscraper/<$ recItem->scraperImage().path $>"
+            <img data-src="/tvscraper/<$ recItem->scraperImage().path $>?size=120"
               class="<$ recItem->scraperImage().width > recItem->scraperImage().height?"thumb":"thumbpt" $>"
             />
           </div>


### PR DESCRIPTION
This PR fixes #74 by introducing a preview size option to the "content" component. The performance is very good even with slow WiFi connection.

- An optional parameter size may specify a target size for the preview image.
E.g.: `/tvscraper/series/308694/1/still_1.jpg?size=120`
Without this parameter the behavior is as before.
- With the size parameter the original image is scaled by DCT decimation. This is a very fast (and old) option of libjpeg which directly discards unnecessary coefficients.
- Stream processing ensures that the original image is never held completely in memory. Only the reduced image is in memory.
- The resulting image may be larger than the requested size, because only powers of 2 are used as decimation factors and the JPEG format uses 8×8 DCT and can decimate at most by ⅛, i.e. up to 64 times less pixels.
- Only JPEG images are processed. I have not found anything else so far.
- If something went wrong, the original files are delivered.
- The recording component and addScraperImageTitle are modified to request images of at least 120 pixels. This typically results in preview images with 120\~240 pixels and 10\~60 kB. At least an order of magnitude less than the original images.
- The images in the detail view of an event are not reduced, although their visible size is limited too.
- For this to work an additional linker dependency to libjpeg is required. This library is used by the VDR core anyway, so in fact it is no _additional_ dependency. The dependency does not use pkg-config because the VDR Makefile also just use `-ljpeg`.
- An additional cache-control header is added to ensure that the browser also caches URLs containing parameters (the defaults differ). I think the images are not likely to change without getting another ID and URL.
- The reduced images are not kept at the server. The browser caches should be sufficient. This also simplifies delivery of differently sized thumbnails in future.
- The invalid mime type image/jpg is fixed.